### PR TITLE
Temporarily add nsp 654 to exception list - we need to wait for a fix

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,12 +1,9 @@
 {
   "exceptions": [
-    "https://nodesecurity.io/advisories/338",
-    "https://nodesecurity.io/advisories/525",
     "https://nodesecurity.io/advisories/532",
-    "https://nodesecurity.io/advisories/534",
-    "https://nodesecurity.io/advisories/535",
-    "https://nodesecurity.io/advisories/566",
     "https://nodesecurity.io/advisories/157",
-    "https://nodesecurity.io/advisories/577"
+    "https://nodesecurity.io/advisories/577",
+    "https://nodesecurity.io/advisories/654",
+    "https://nodesecurity.io/advisories/664"
   ]
 }


### PR DESCRIPTION
NSP vulnerability [654](https://nodesecurity.io/advisories/654) is critical, but we need to wait for a fix to be available.

Related:
https://github.com/facebook/create-react-app/issues/4479

path from CRA forward:
css-loader@0.28.7 > cssnano@3.10.0 > postcss-filter-plugins@2.0.2 > uniqid@4.1.1 > macaddress@0.2.8