### PR TITLE
Remove custom touched handling from FieldCheckboxGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ way to update this template, but currently, we follow a pattern:
   cause conflicts.
 * Patch (v0.0.**X**): Bug fixes and small changes to components.
 
+----
+
+## Upcoming version
+
+* Remove custom touched handling from `FieldCheckboxGroup` as it has has become obsolete now that
+  Final Form is replacing Redux Form. [#837](https://github.com/sharetribe/flex-template-web/pull/837) 
+
 ## v0.2.0
 
-* Starting a change log for Flex Template for Web
+* Starting a change log for Flex Template for Web.

--- a/src/components/FieldCheckboxGroup/FieldCheckboxGroup.js
+++ b/src/components/FieldCheckboxGroup/FieldCheckboxGroup.js
@@ -11,7 +11,7 @@
  *
  */
 
-import React, { Component } from 'react';
+import React from 'react';
 import { arrayOf, bool, node, shape, string } from 'prop-types';
 import classNames from 'classnames';
 import { FieldArray } from 'react-final-form-arrays';
@@ -19,50 +19,34 @@ import { FieldCheckbox, ValidationError } from '../../components';
 
 import css from './FieldCheckboxGroup.css';
 
-class FieldCheckboxRenderer extends Component {
-  constructor(props) {
-    super(props);
-    this.state = { touched: false };
-  }
+const FieldCheckboxRenderer = props => {
+  const { className, rootClassName, label, twoColumns, id, fields, options, meta } = props;
 
-  componentWillReceiveProps(nextProps) {
-    // FieldArray doesn't have touched prop, so we'll keep track of it
-    if (!this.state.touched) {
-      this.setState({ touched: nextProps.meta.dirty });
-    }
-  }
+  const classes = classNames(rootClassName || css.root, className);
+  const listClasses = twoColumns ? classNames(css.list, css.twoColumns) : css.list;
 
-  render() {
-    const { className, rootClassName, label, twoColumns, id, fields, options, meta } = this.props;
-
-    const touched = this.state.touched;
-
-    const classes = classNames(rootClassName || css.root, className);
-    const listClasses = twoColumns ? classNames(css.list, css.twoColumns) : css.list;
-
-    return (
-      <fieldset className={classes}>
-        {label ? <legend>{label}</legend> : null}
-        <ul className={listClasses}>
-          {options.map((option, index) => {
-            const fieldId = `${id}.${option.key}`;
-            return (
-              <li key={fieldId} className={css.item}>
-                <FieldCheckbox
-                  id={fieldId}
-                  name={fields.name}
-                  label={option.label}
-                  value={option.key}
-                />
-              </li>
-            );
-          })}
-        </ul>
-        <ValidationError fieldMeta={{ ...meta, touched }} />
-      </fieldset>
-    );
-  }
-}
+  return (
+    <fieldset className={classes}>
+      {label ? <legend>{label}</legend> : null}
+      <ul className={listClasses}>
+        {options.map((option, index) => {
+          const fieldId = `${id}.${option.key}`;
+          return (
+            <li key={fieldId} className={css.item}>
+              <FieldCheckbox
+                id={fieldId}
+                name={fields.name}
+                label={option.label}
+                value={option.key}
+              />
+            </li>
+          );
+        })}
+      </ul>
+      <ValidationError fieldMeta={{ ...meta }} />
+    </fieldset>
+  );
+};
 
 FieldCheckboxRenderer.defaultProps = {
   rootClassName: null,


### PR DESCRIPTION
Remove custom touched handling that was needed with the FieldArray in
Redux Form but is not needed anymore with Final Form.