### PR TITLE
Fix missing profile image variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ way to update this template, but currently, we follow a pattern:
   [#846](https://github.com/sharetribe/flex-template-web/pull/846)
 * [fix] Add missing styles for ModalMissingInformation from Topbar
   [#847](https://github.com/sharetribe/flex-template-web/pull/847)
+* [fix] API does not return all image variants anymore, this adds correct variants to update
+  contact details call.
+  [#848](https://github.com/sharetribe/flex-template-web/pull/848)
 
 ## v0.3.1
 

--- a/src/containers/ContactDetailsPage/ContactDetailsPage.duck.js
+++ b/src/containers/ContactDetailsPage/ContactDetailsPage.duck.js
@@ -79,7 +79,14 @@ const requestSavePhoneNumber = params => (dispatch, getState, sdk) => {
   const phoneNumber = params.phoneNumber;
 
   return sdk.currentUser
-    .updateProfile({ protectedData: { phoneNumber } }, { expand: true, include: ['profileImage'] })
+    .updateProfile(
+      { protectedData: { phoneNumber } },
+      {
+        expand: true,
+        include: ['profileImage'],
+        'fields.image': ['variants.square-small', 'variants.square-small2x'],
+      }
+    )
     .then(response => {
       const entities = denormalisedResponseEntities(response);
       if (entities.length !== 1) {
@@ -104,7 +111,14 @@ const requestSaveEmail = params => (dispatch, getState, sdk) => {
   const { email, currentPassword } = params;
 
   return sdk.currentUser
-    .changeEmail({ email, currentPassword }, { expand: true, include: ['profileImage'] })
+    .changeEmail(
+      { email, currentPassword },
+      {
+        expand: true,
+        include: ['profileImage'],
+        'fields.image': ['variants.square-small', 'variants.square-small2x'],
+      }
+    )
     .then(response => {
       const entities = denormalisedResponseEntities(response);
       if (entities.length !== 1) {


### PR DESCRIPTION
API has changed at some point - id doesn't return all the image variants but only defaults. 
For profile image (avatar), this means that we need to specify image variants always when requested.