### PR TITLE
Fix Topbar search initial value

### DIFF
--- a/src/components/SectionHero/SectionHero.js
+++ b/src/components/SectionHero/SectionHero.js
@@ -7,6 +7,7 @@ import { createResourceLocatorString } from '../../util/routes';
 import routeConfiguration from '../../routeConfiguration';
 import { IconSearch, Button } from '../../components';
 import { LocationSearchForm } from '../../forms';
+import config from '../../config';
 
 import css from './SectionHero.css';
 
@@ -22,7 +23,8 @@ const SectionHero = props => {
   const handleSearchSubmit = values => {
     const { search, selectedPlace } = values.location;
     const { origin, bounds, country } = selectedPlace;
-    const searchParams = { address: search, origin, bounds, country };
+    const originMaybe = config.sortSearchByDistance ? { origin } : {};
+    const searchParams = { ...originMaybe, address: search, bounds, country };
     history.push(createResourceLocatorString('SearchPage', routeConfiguration(), {}, searchParams));
   };
 

--- a/src/components/Topbar/Topbar.js
+++ b/src/components/Topbar/Topbar.js
@@ -174,7 +174,7 @@ class TopbarComponent extends Component {
     );
 
     // Only render current search if full place object is available in the URL params
-    const locationFieldsPresent = address && origin && bounds && country;
+    const locationFieldsPresent = address && bounds && country;
     const initialSearchFormValues = {
       location: locationFieldsPresent
         ? {

--- a/src/util/types.js
+++ b/src/util/types.js
@@ -70,7 +70,7 @@ propTypes.route = shape({
 // Place object from LocationAutocompleteInput
 propTypes.place = shape({
   address: string.isRequired,
-  origin: propTypes.latlng.isRequired,
+  origin: propTypes.latlng,
   bounds: propTypes.latlngBounds, // optional viewport bounds
   country: string, // country code, e.g. FI, US
 });


### PR DESCRIPTION
Fixes showing the searched address in the Topbar search form after a search conducted from the Topbar.

Makes the `origin` attribute optional in `propTypes.place` in src/util/types.js as it is not used in case the `sortSearchByDistance` is not set in config.