### PR TITLE
Fix clearing tx initial message before the page change is made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version
 
+* [fix] Fix initial message input clearing too early in checkout page.
+  [#861](https://github.com/sharetribe/flex-template-web/pull/861)
 * [fix] Fix setting Topbar search input initial value.
   [#857](https://github.com/sharetribe/flex-template-web/pull/857)
 

--- a/src/forms/StripePaymentForm/StripePaymentForm.js
+++ b/src/forms/StripePaymentForm/StripePaymentForm.js
@@ -113,9 +113,6 @@ class StripePaymentForm extends Component {
       }
     });
   }
-  componentWillReceiveProps() {
-    this.setState(initialState);
-  }
   componentWillUnmount() {
     if (this.card) {
       this.card.removeEventListener('change', this.handleCardValueChange);

--- a/src/forms/StripePaymentForm/StripePaymentForm.js
+++ b/src/forms/StripePaymentForm/StripePaymentForm.js
@@ -199,7 +199,7 @@ class StripePaymentForm extends Component {
     const classes = classNames(rootClassName || css.root, className);
     const cardClasses = classNames(css.card, {
       [css.cardSuccess]: this.state.cardValueValid,
-      [css.cardError]: this.state.error,
+      [css.cardError]: this.state.error && !submitInProgress,
     });
 
     const messagePlaceholder = intl.formatMessage(
@@ -240,7 +240,9 @@ class StripePaymentForm extends Component {
             this.cardContainer = el;
           }}
         />
-        {this.state.error ? <span style={{ color: 'red' }}>{this.state.error}</span> : null}
+        {this.state.error && !submitInProgress ? (
+          <span style={{ color: 'red' }}>{this.state.error}</span>
+        ) : null}
         <h3 className={css.messageHeading}>
           <FormattedMessage id="StripePaymentForm.messageHeading" />
         </h3>


### PR DESCRIPTION
Fixes a UI bug on checkout page where the initial message input is cleared slightly before the page changes to the tx page.

__Before:__
![message_blink_before](https://user-images.githubusercontent.com/57473/42336089-38cc91be-808b-11e8-9806-620b91792e2f.gif)


__After:__
![message_blink_after](https://user-images.githubusercontent.com/57473/42336098-406a82a0-808b-11e8-9934-0af949465762.gif)
