### PR TITLE
Add clear errors action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ way to update this template, but currently, we follow a pattern:
 
 * [fix] Fix submit button state on contact details page
   [#864](https://github.com/sharetribe/flex-template-web/pull/864)
+* [fix] Fix passing initial message sending error to transaction page.
+  [#863](https://github.com/sharetribe/flex-template-web/pull/863)
 * [fix] Fix initial message input clearing too early in checkout page.
   [#861](https://github.com/sharetribe/flex-template-web/pull/861)
 * [fix] Fix setting Topbar search input initial value.

--- a/src/containers/TransactionPage/TransactionPage.duck.js
+++ b/src/containers/TransactionPage/TransactionPage.duck.js
@@ -27,6 +27,8 @@ const CUSTOMER = 'customer';
 
 export const SET_INITAL_VALUES = 'app/TransactionPage/SET_INITIAL_VALUES';
 
+export const CLEAR_ERRORS = 'app/TransactionPage/CLEAR_ERRORS';
+
 export const FETCH_TRANSACTION_REQUEST = 'app/TransactionPage/FETCH_TRANSACTION_REQUEST';
 export const FETCH_TRANSACTION_SUCCESS = 'app/TransactionPage/FETCH_TRANSACTION_SUCCESS';
 export const FETCH_TRANSACTION_ERROR = 'app/TransactionPage/FETCH_TRANSACTION_ERROR';
@@ -89,6 +91,9 @@ export default function checkoutPageReducer(state = initialState, action = {}) {
     case SET_INITAL_VALUES:
       return { ...initialState, ...payload };
 
+    case CLEAR_ERRORS:
+      return { ...state, sendMessageError: null, sendReviewError: null };
+
     case FETCH_TRANSACTION_REQUEST:
       return { ...state, fetchTransactionInProgress: true, fetchTransactionError: null };
     case FETCH_TRANSACTION_SUCCESS: {
@@ -133,7 +138,12 @@ export default function checkoutPageReducer(state = initialState, action = {}) {
       return { ...state, fetchMessagesInProgress: false, fetchMessagesError: payload };
 
     case SEND_MESSAGE_REQUEST:
-      return { ...state, sendMessageInProgress: true, sendMessageError: null };
+      return {
+        ...state,
+        sendMessageInProgress: true,
+        sendMessageError: null,
+        initialMessageFailedToTransaction: null,
+      };
     case SEND_MESSAGE_SUCCESS:
       return { ...state, sendMessageInProgress: false };
     case SEND_MESSAGE_ERROR:
@@ -162,6 +172,9 @@ export const setInitialValues = initialValues => ({
   type: SET_INITAL_VALUES,
   payload: pick(initialValues, Object.keys(initialState)),
 });
+
+// clears tx page message and review sending errors
+const clearErrors = () => ({ type: CLEAR_ERRORS });
 
 const fetchTransactionRequest = () => ({ type: FETCH_TRANSACTION_REQUEST });
 const fetchTransactionSuccess = response => ({
@@ -470,7 +483,7 @@ export const loadData = params => dispatch => {
   const txId = new UUID(params.id);
 
   // Clear the send error since the message form is emptied as well.
-  dispatch(setInitialValues({ sendMessageError: null, sendReviewError: null }));
+  dispatch(clearErrors());
 
   // Sale / order (i.e. transaction entity in API)
   return Promise.all([dispatch(fetchTransaction(txId)), dispatch(fetchMessages(txId, 1))]);


### PR DESCRIPTION
Add an action that can be used to clear errors on load data instead of
clearing the whole state.

Fixes passing an initial message sending error to the tx page. The initial message sending error is cleared when a new send message request is fired. Downside to this is that the initial message error is not cleared between component loads in case sending the message is not tried again.