### PR TITLE
Change clearErrors action to resetState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version
 
-* [fix] Fix submit button state on contact details page
+* [fix] Fix TransactionPage state management in loadData.
+  [#863](https://github.com/sharetribe/flex-template-web/pull/863) & [#865](https://github.com/sharetribe/flex-template-web/pull/865)
+* [fix] Fix submit button state on contact details page.
   [#864](https://github.com/sharetribe/flex-template-web/pull/864)
 * [fix] Fix passing initial message sending error to transaction page.
   [#863](https://github.com/sharetribe/flex-template-web/pull/863)

--- a/src/containers/TransactionPage/TransactionPage.duck.js
+++ b/src/containers/TransactionPage/TransactionPage.duck.js
@@ -27,7 +27,7 @@ const CUSTOMER = 'customer';
 
 export const SET_INITAL_VALUES = 'app/TransactionPage/SET_INITIAL_VALUES';
 
-export const CLEAR_ERRORS = 'app/TransactionPage/CLEAR_ERRORS';
+export const RESET_STATE = 'app/TransactionPage/RESET_STATE';
 
 export const FETCH_TRANSACTION_REQUEST = 'app/TransactionPage/FETCH_TRANSACTION_REQUEST';
 export const FETCH_TRANSACTION_SUCCESS = 'app/TransactionPage/FETCH_TRANSACTION_SUCCESS';
@@ -91,8 +91,8 @@ export default function checkoutPageReducer(state = initialState, action = {}) {
     case SET_INITAL_VALUES:
       return { ...initialState, ...payload };
 
-    case CLEAR_ERRORS:
-      return { ...state, sendMessageError: null, sendReviewError: null };
+    case RESET_STATE:
+      return { ...state, sendMessageError: null, sendReviewError: null, messages: [] };
 
     case FETCH_TRANSACTION_REQUEST:
       return { ...state, fetchTransactionInProgress: true, fetchTransactionError: null };
@@ -174,7 +174,7 @@ export const setInitialValues = initialValues => ({
 });
 
 // clears tx page message and review sending errors
-const clearErrors = () => ({ type: CLEAR_ERRORS });
+const resetState = () => ({ type: RESET_STATE });
 
 const fetchTransactionRequest = () => ({ type: FETCH_TRANSACTION_REQUEST });
 const fetchTransactionSuccess = response => ({
@@ -483,7 +483,7 @@ export const loadData = params => dispatch => {
   const txId = new UUID(params.id);
 
   // Clear the send error since the message form is emptied as well.
-  dispatch(clearErrors());
+  dispatch(resetState());
 
   // Sale / order (i.e. transaction entity in API)
   return Promise.all([dispatch(fetchTransaction(txId)), dispatch(fetchMessages(txId, 1))]);


### PR DESCRIPTION
#863 changed the `TransactionPage.duck.js` so that the `loadData` function did not clear the whole state anymore but instead just cleared any possible errors in the state. This fixed a bug where any errors caused from sending an initial message in the checkout page were not passed to the tx page. Unfortunately, this also introduced a new bug. As the reducer uses messages in the state to create paging for the messages, old messages we're left hanging in the state and unrelated messages started showing up in activity feeds.

This PR removes the `clearErrors` action and introduces an action called `resetState` which in addition to clearing the errors also clears messages from the state.

Suggestions for a more accurate name for `resetState` are welcome.