### PR TITLE
Improve tx page state management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version
 
-* [fix] Fix TransactionPage state management in loadData.
-  [#863](https://github.com/sharetribe/flex-template-web/pull/863) & [#865](https://github.com/sharetribe/flex-template-web/pull/865)
+* [change] Change TransactionPage state management in loadData.
+  [#863](https://github.com/sharetribe/flex-template-web/pull/863), [#865](https://github.com/sharetribe/flex-template-web/pull/865) & [#866](https://github.com/sharetribe/flex-template-web/pull/866)
 * [fix] Fix submit button state on contact details page.
   [#864](https://github.com/sharetribe/flex-template-web/pull/864)
-* [fix] Fix passing initial message sending error to transaction page.
-  [#863](https://github.com/sharetribe/flex-template-web/pull/863)
 * [fix] Fix listing page host section layout bug.
   [#862](https://github.com/sharetribe/flex-template-web/pull/862)
 * [fix] Fix initial message input clearing too early in checkout page.

--- a/src/containers/TransactionPage/TransactionPage.duck.js
+++ b/src/containers/TransactionPage/TransactionPage.duck.js
@@ -1,4 +1,5 @@
 import pick from 'lodash/pick';
+import pickBy from 'lodash/pickBy';
 import { types as sdkTypes } from '../../util/sdkLoader';
 import { isTransactionsTransitionInvalidTransition, storableError } from '../../util/errors';
 import {
@@ -26,8 +27,6 @@ const CUSTOMER = 'customer';
 // ================ Action types ================ //
 
 export const SET_INITAL_VALUES = 'app/TransactionPage/SET_INITIAL_VALUES';
-
-export const RESET_STATE = 'app/TransactionPage/RESET_STATE';
 
 export const FETCH_TRANSACTION_REQUEST = 'app/TransactionPage/FETCH_TRANSACTION_REQUEST';
 export const FETCH_TRANSACTION_SUCCESS = 'app/TransactionPage/FETCH_TRANSACTION_SUCCESS';
@@ -90,9 +89,6 @@ export default function checkoutPageReducer(state = initialState, action = {}) {
   switch (type) {
     case SET_INITAL_VALUES:
       return { ...initialState, ...payload };
-
-    case RESET_STATE:
-      return { ...state, sendMessageError: null, sendReviewError: null, messages: [] };
 
     case FETCH_TRANSACTION_REQUEST:
       return { ...state, fetchTransactionInProgress: true, fetchTransactionError: null };
@@ -172,9 +168,6 @@ export const setInitialValues = initialValues => ({
   type: SET_INITAL_VALUES,
   payload: pick(initialValues, Object.keys(initialState)),
 });
-
-// clears tx page message and review sending errors
-const resetState = () => ({ type: RESET_STATE });
 
 const fetchTransactionRequest = () => ({ type: FETCH_TRANSACTION_REQUEST });
 const fetchTransactionSuccess = response => ({
@@ -479,11 +472,16 @@ export const sendReview = (role, tx, reviewRating, reviewContent) => (dispatch, 
 
 // loadData is a collection of async calls that need to be made
 // before page has all the info it needs to render itself
-export const loadData = params => dispatch => {
+export const loadData = params => (dispatch, getState) => {
   const txId = new UUID(params.id);
+  const state = getState().TransactionPage;
+  const txRef = state.transactionRef;
 
-  // Clear the send error since the message form is emptied as well.
-  dispatch(resetState());
+  // In case a transaction reference is found from a previous
+  // data load -> clear the state. Otherwise keep the non-null
+  // values which may have been set from a previous page.
+  const initialValues = txRef ? {} : pickBy(state, v => !!v);
+  dispatch(setInitialValues(initialValues));
 
   // Sale / order (i.e. transaction entity in API)
   return Promise.all([dispatch(fetchTransaction(txId)), dispatch(fetchMessages(txId, 1))]);

--- a/src/containers/TransactionPage/TransactionPage.duck.js
+++ b/src/containers/TransactionPage/TransactionPage.duck.js
@@ -1,5 +1,6 @@
 import pick from 'lodash/pick';
 import pickBy from 'lodash/pickBy';
+import isEmpty from 'lodash/isEmpty';
 import { types as sdkTypes } from '../../util/sdkLoader';
 import { isTransactionsTransitionInvalidTransition, storableError } from '../../util/errors';
 import {
@@ -470,6 +471,10 @@ export const sendReview = (role, tx, reviewRating, reviewContent) => (dispatch, 
     : sendReviewAsFirst(tx.id, params, role, dispatch, sdk);
 };
 
+const isNonEmpty = value => {
+  return typeof value === 'object' || Array.isArray(value) ? !isEmpty(value) : !!value;
+};
+
 // loadData is a collection of async calls that need to be made
 // before page has all the info it needs to render itself
 export const loadData = params => (dispatch, getState) => {
@@ -479,8 +484,8 @@ export const loadData = params => (dispatch, getState) => {
 
   // In case a transaction reference is found from a previous
   // data load -> clear the state. Otherwise keep the non-null
-  // values which may have been set from a previous page.
-  const initialValues = txRef ? {} : pickBy(state, v => !!v);
+  // and non-empty values which may have been set from a previous page.
+  const initialValues = txRef ? {} : pickBy(state, isNonEmpty);
   dispatch(setInitialValues(initialValues));
 
   // Sale / order (i.e. transaction entity in API)


### PR DESCRIPTION
The state management in the `loadData` function in `TransactionPage.duck` has been somewhat problematic and this PR aims to improve it.

Now `loadData` checks if a `transactionRef` is found from state. It is set when a tx fetch succeeds. If a `transactionRef` is found it means the state holds data from a previous page load and the state is cleared. If the ref can not be found it means that the page has not been loaded or that the `setInitialValues` has been invoked for example with an initial message sending error information from `CheckoutPage`.