### PR TITLE
Add sessiontoken and sparse fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ way to update this template, but currently, we follow a pattern:
 ---
 
 ## Upcoming version
-
+* [change] Use sessionTokens and fields for Autocomplete calls to Google Maps.
+  This is a reaction to pricing change of Google Maps APIs.
+  [#867](https://github.com/sharetribe/flex-template-web/pull/867)
 * [change] Change TransactionPage state management in loadData.
   [#863](https://github.com/sharetribe/flex-template-web/pull/863), [#865](https://github.com/sharetribe/flex-template-web/pull/865) & [#866](https://github.com/sharetribe/flex-template-web/pull/866)
 * [fix] Fix submit button state on contact details page.

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInput.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInput.js
@@ -217,7 +217,6 @@ class LocationAutocompleteInput extends Component {
     this.setState({ highlightedIndex: -1 });
 
     if (!newValue) {
-      this.autocompleteSessionToken = null;
       // No need to fetch predictions on empty input
       return;
     }

--- a/src/util/googleMaps.js
+++ b/src/util/googleMaps.js
@@ -47,9 +47,10 @@ export const getPlaceDetails = (placeId, sessionToken) =>
     const serviceStatus = window.google.maps.places.PlacesServiceStatus;
     const el = document.createElement('div');
     const service = new window.google.maps.places.PlacesService(el);
+    const fields = ['address_component', 'formatted_address', 'geometry', 'place_id'];
     const sessionTokenMaybe = sessionToken ? { sessionToken } : {};
 
-    service.getDetails({ placeId, ...sessionTokenMaybe }, (place, status) => {
+    service.getDetails({ placeId, fields, ...sessionTokenMaybe }, (place, status) => {
       if (status !== serviceStatus.OK) {
         reject(
           new Error(`Could not get details for place id "${placeId}", error status was "${status}"`)

--- a/src/util/googleMaps.js
+++ b/src/util/googleMaps.js
@@ -36,17 +36,20 @@ const placeCountry = place => {
  *
  * @param {String} placeId - ID for a place received from the
  * autocomplete service
+ * @param {String} sessionToken - token to tie different autocomplete character searches together
+ * with getPlaceDetails call
  *
  * @return {Promise<util.propTypes.place>} Promise that
  * resolves to the detailed place, rejects if the request failed
  */
-export const getPlaceDetails = placeId =>
+export const getPlaceDetails = (placeId, sessionToken) =>
   new Promise((resolve, reject) => {
     const serviceStatus = window.google.maps.places.PlacesServiceStatus;
     const el = document.createElement('div');
     const service = new window.google.maps.places.PlacesService(el);
+    const sessionTokenMaybe = sessionToken ? { sessionToken } : {};
 
-    service.getDetails({ placeId }, (place, status) => {
+    service.getDetails({ placeId, ...sessionTokenMaybe }, (place, status) => {
       if (status !== serviceStatus.OK) {
         reject(
           new Error(`Could not get details for place id "${placeId}", error status was "${status}"`)
@@ -71,16 +74,19 @@ const predictionSuccessful = status => {
  * Get place predictions for the given search
  *
  * @param {String} search - place name or address to search
+ * @param {String} sessionToken - token to tie different autocomplete character searches together
+ * with getPlaceDetails call
  *
  * @return {Promise<{ search, predictions[] }>} - Promise of an object
  * with the original search query and an array of
  * `google.maps.places.AutocompletePrediction` objects
  */
-export const getPlacePredictions = search =>
+export const getPlacePredictions = (search, sessionToken) =>
   new Promise((resolve, reject) => {
     const service = new window.google.maps.places.AutocompleteService();
+    const sessionTokenMaybe = sessionToken ? { sessionToken } : {};
 
-    service.getPlacePredictions({ input: search }, (predictions, status) => {
+    service.getPlacePredictions({ input: search, ...sessionTokenMaybe }, (predictions, status) => {
       if (!predictionSuccessful(status)) {
         reject(new Error(`Prediction service status not OK: ${status}`));
       } else {


### PR DESCRIPTION
This is a reaction to Google Maps pricing change: 
- Added sessionToken to Autocomplete calls (otherwise calls are prices separately)
- Use sparse fields for place details call (otherwise all the data is returned and it costs more)