### PR TITLE
Reusable SearchMap

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -4,6 +4,7 @@
     "https://nodesecurity.io/advisories/157",
     "https://nodesecurity.io/advisories/577",
     "https://nodesecurity.io/advisories/654",
-    "https://nodesecurity.io/advisories/664"
+    "https://nodesecurity.io/advisories/664",
+    "https://nodesecurity.io/advisories/678"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ way to update this template, but currently, we follow a pattern:
 * Patch (v0.0.**X**): Bug fixes and small changes to components.
 
 ---
+## Upcoming version 2018-08-XX
+* [change] Reusable SearchMap. Fixed the original reverted version. (Includes audit exception 678)
+  [#882](https://github.com/sharetribe/flex-template-web/pull/882)
+
 ## v1.3.1
 * [fix] Hotfix: reverting the usage of ReusableMapContainer due to
   production build error.

--- a/src/components/SearchMap/SearchMap.js
+++ b/src/components/SearchMap/SearchMap.js
@@ -12,6 +12,7 @@ import { googleBoundsToSDKBounds } from '../../util/googleMaps';
 import { SearchMapInfoCard, SearchMapPriceLabel, SearchMapGroupLabel } from '../../components';
 import config from '../../config';
 
+import ReusableMapContainer from './ReusableMapContainer';
 import css from './SearchMap.css';
 
 const LABEL_HANDLE = 'SearchMapLabel';
@@ -240,6 +241,7 @@ export class SearchMapComponent extends Component {
     const {
       className,
       rootClassName,
+      reusableContainerClassName,
       center,
       isOpenOnModal,
       listings: originalListings,
@@ -263,28 +265,30 @@ export class SearchMapComponent extends Component {
     // container element listens clicks so that opened SearchMapInfoCard can be closed
     /* eslint-disable jsx-a11y/no-static-element-interactions */
     return isMapsLibLoaded ? (
-      <MapWithGoogleMap
-        containerElement={<div className={classes} onClick={this.onMapClicked} />}
-        mapElement={<div className={mapClasses} />}
-        center={center}
-        isOpenOnModal={isOpenOnModal}
-        listings={listings}
-        activeListingId={activeListingId}
-        infoCardOpen={this.state.infoCardOpen}
-        onListingClicked={this.onListingClicked}
-        onMapLoad={this.onMapLoadHandler}
-        onIdle={() => {
-          if (this.googleMap) {
-            onIdle(this.googleMap);
-          }
-        }}
-        onCloseAsModal={() => {
-          if (onCloseAsModal) {
-            onCloseAsModal();
-          }
-        }}
-        zoom={zoom}
-      />
+      <ReusableMapContainer className={reusableContainerClassName}>
+        <MapWithGoogleMap
+          containerElement={<div className={classes} onClick={this.onMapClicked} />}
+          mapElement={<div className={mapClasses} />}
+          center={center}
+          isOpenOnModal={isOpenOnModal}
+          listings={listings}
+          activeListingId={activeListingId}
+          infoCardOpen={this.state.infoCardOpen}
+          onListingClicked={this.onListingClicked}
+          onMapLoad={this.onMapLoadHandler}
+          onIdle={() => {
+            if (this.googleMap) {
+              onIdle(this.googleMap);
+            }
+          }}
+          onCloseAsModal={() => {
+            if (onCloseAsModal) {
+              onCloseAsModal();
+            }
+          }}
+          zoom={zoom}
+        />
+      </ReusableMapContainer>
     ) : (
       <div className={classes} />
     );
@@ -296,6 +300,7 @@ SearchMapComponent.defaultProps = {
   className: null,
   rootClassName: null,
   mapRootClassName: null,
+  reusableContainerClassName: null,
   bounds: null,
   center: new sdkTypes.LatLng(0, 0),
   activeListingId: null,
@@ -311,6 +316,7 @@ SearchMapComponent.propTypes = {
   className: string,
   rootClassName: string,
   mapRootClassName: string,
+  reusableContainerClassName: string,
   bounds: propTypes.latlngBounds,
   center: propTypes.latlng,
   activeListingId: propTypes.uuid,

--- a/src/components/SearchMap/SearchMap.js
+++ b/src/components/SearchMap/SearchMap.js
@@ -1,10 +1,14 @@
 import React, { Component } from 'react';
 import { arrayOf, bool, func, number, string, shape } from 'prop-types';
+import { withRouter } from 'react-router-dom';
 import { withGoogleMap, GoogleMap } from 'react-google-maps';
 import classNames from 'classnames';
 import groupBy from 'lodash/groupBy';
 import isEqual from 'lodash/isEqual';
 import reduce from 'lodash/reduce';
+import routeConfiguration from '../../routeConfiguration';
+import { createResourceLocatorString } from '../../util/routes';
+import { createSlug } from '../../util/urlHelpers';
 import { types as sdkTypes } from '../../util/sdkLoader';
 import { propTypes } from '../../util/types';
 import { obfuscatedCoordinates } from '../../util/maps';
@@ -98,11 +102,13 @@ const MapWithGoogleMap = withGoogleMap(props => {
     infoCardOpen,
     isOpenOnModal,
     listings,
-    onCloseAsModal,
     onIdle,
     onListingClicked,
+    onListingInfoCardClicked,
+    createURLToListing,
     onMapLoad,
     zoom,
+    mapComponentRefreshToken,
   } = props;
 
   const listingArraysInLocations = reducedToArray(groupedByCoordinates(listings));
@@ -127,6 +133,7 @@ const MapWithGoogleMap = withGoogleMap(props => {
           className={LABEL_HANDLE}
           listing={listing}
           onListingClicked={onListingClicked}
+          mapComponentRefreshToken={mapComponentRefreshToken}
         />
       );
     }
@@ -137,6 +144,7 @@ const MapWithGoogleMap = withGoogleMap(props => {
         className={LABEL_HANDLE}
         listings={listingArr}
         onListingClicked={onListingClicked}
+        mapComponentRefreshToken={mapComponentRefreshToken}
       />
     );
   });
@@ -145,9 +153,11 @@ const MapWithGoogleMap = withGoogleMap(props => {
   const openedCard = infoCardOpen ? (
     <SearchMapInfoCard
       key={listingsArray[0].id.uuid}
+      mapComponentRefreshToken={mapComponentRefreshToken}
       className={INFO_CARD_HANDLE}
       listings={listingsArray}
-      onClickCallback={onCloseAsModal}
+      onListingInfoCardClicked={onListingInfoCardClicked}
+      createURLToListing={createURLToListing}
     />
   ) : null;
 
@@ -192,7 +202,11 @@ export class SearchMapComponent extends Component {
 
     this.listings = [];
     this.googleMap = null;
+    this.mapReattachmentCount = 0;
     this.state = { infoCardOpen: null };
+
+    this.createURLToListing = this.createURLToListing.bind(this);
+    this.onListingInfoCardClicked = this.onListingInfoCardClicked.bind(this);
     this.onListingClicked = this.onListingClicked.bind(this);
     this.onMapClicked = this.onMapClicked.bind(this);
     this.onMapLoadHandler = this.onMapLoadHandler.bind(this);
@@ -215,8 +229,28 @@ export class SearchMapComponent extends Component {
     this.listings = [];
   }
 
+  createURLToListing(listing) {
+    const routes = routeConfiguration();
+
+    const id = listing.id.uuid;
+    const slug = createSlug(listing.attributes.title);
+    const pathParams = { id, slug };
+
+    return createResourceLocatorString('ListingPage', routes, pathParams, {});
+  }
+
   onListingClicked(listings) {
     this.setState({ infoCardOpen: listings });
+  }
+
+  onListingInfoCardClicked(listing) {
+    if (this.props.onCloseAsModal) {
+      this.props.onCloseAsModal();
+    }
+
+    // To avoid full page refresh we need to use internal router
+    const history = this.props.history;
+    history.push(this.createURLToListing(listing));
   }
 
   onMapClicked(e) {
@@ -259,13 +293,18 @@ export class SearchMapComponent extends Component {
     const listings = coordinatesConfig.fuzzy
       ? withCoordinatesObfuscated(listingsWithLocation)
       : listingsWithLocation;
+    const infoCardOpen = this.state.infoCardOpen;
 
     const isMapsLibLoaded = typeof window !== 'undefined' && window.google && window.google.maps;
+
+    const forceUpdateHandler = () => {
+      this.mapReattachmentCount += 1;
+    };
 
     // container element listens clicks so that opened SearchMapInfoCard can be closed
     /* eslint-disable jsx-a11y/no-static-element-interactions */
     return isMapsLibLoaded ? (
-      <ReusableMapContainer className={reusableContainerClassName}>
+      <ReusableMapContainer className={reusableContainerClassName} onReattach={forceUpdateHandler}>
         <MapWithGoogleMap
           containerElement={<div className={classes} onClick={this.onMapClicked} />}
           mapElement={<div className={mapClasses} />}
@@ -273,8 +312,10 @@ export class SearchMapComponent extends Component {
           isOpenOnModal={isOpenOnModal}
           listings={listings}
           activeListingId={activeListingId}
-          infoCardOpen={this.state.infoCardOpen}
+          infoCardOpen={infoCardOpen}
           onListingClicked={this.onListingClicked}
+          onListingInfoCardClicked={this.onListingInfoCardClicked}
+          createURLToListing={this.createURLToListing}
           onMapLoad={this.onMapLoadHandler}
           onIdle={() => {
             if (this.googleMap) {
@@ -287,6 +328,7 @@ export class SearchMapComponent extends Component {
             }
           }}
           zoom={zoom}
+          mapComponentRefreshToken={this.mapReattachmentCount}
         />
       </ReusableMapContainer>
     ) : (
@@ -329,8 +371,13 @@ SearchMapComponent.propTypes = {
   coordinatesConfig: shape({
     fuzzy: bool.isRequired,
   }),
+
+  // from withRouter
+  history: shape({
+    push: func.isRequired,
+  }).isRequired,
 };
 
-const SearchMap = SearchMapComponent;
+const SearchMap = withRouter(SearchMapComponent);
 
 export default SearchMap;

--- a/src/containers/SearchPage/SearchPage.js
+++ b/src/containers/SearchPage/SearchPage.js
@@ -251,9 +251,10 @@ export class SearchPageComponent extends Component {
             showAsModalMaxWidth={MODAL_BREAKPOINT}
             onManageDisableScrolling={onManageDisableScrolling}
           >
-            <div className={css.map}>
+            <div className={css.mapWrapper}>
               {shouldShowSearchMap ? (
                 <SearchMap
+                  reusableContainerClassName={css.map}
                   activeListingId={activeListingId}
                   bounds={bounds}
                   center={origin}

--- a/src/containers/SearchPage/__snapshots__/SearchPage.test.js.snap
+++ b/src/containers/SearchPage/__snapshots__/SearchPage.test.js.snap
@@ -116,6 +116,7 @@ exports[`SearchPageComponent matches snapshot 1`] = `
           mapRootClassName={null}
           onCloseAsModal={[Function]}
           onIdle={[Function]}
+          reuseableContainerClassName={null}
           rootClassName={null}
           useLocationSearchBounds={true}
           zoom={11}

--- a/src/containers/SearchPage/__snapshots__/SearchPage.test.js.snap
+++ b/src/containers/SearchPage/__snapshots__/SearchPage.test.js.snap
@@ -86,40 +86,13 @@ exports[`SearchPageComponent matches snapshot 1`] = `
       showAsModalMaxWidth={768}
     >
       <div>
-        <SearchMapComponent
+        <withRouter(SearchMapComponent)
           activeListingId={null}
-          bounds={null}
-          center={
-            LatLng {
-              "lat": 0,
-              "lng": 0,
-            }
-          }
-          className={null}
-          coordinatesConfig={
-            Object {
-              "circleOptions": Object {
-                "clickable": false,
-                "fillColor": "#c0392b",
-                "fillOpacity": 0.2,
-                "strokeColor": "#c0392b",
-                "strokeOpacity": 0.5,
-                "strokeWeight": 1,
-              },
-              "coordinateOffset": 500,
-              "fuzzy": false,
-              "fuzzyDefaultZoomLevel": 14,
-            }
-          }
           isOpenOnModal={false}
           listings={Array []}
-          mapRootClassName={null}
           onCloseAsModal={[Function]}
           onIdle={[Function]}
-          reuseableContainerClassName={null}
-          rootClassName={null}
           useLocationSearchBounds={true}
-          zoom={11}
         />
       </div>
     </withViewport(ModalInMobileComponent)>


### PR DESCRIPTION
Improved version of ReusableMapContainer (the original version was buggy).

This is needed for:
- Performance: no need to load dynamic map every time user enters the search page view on SPA.
- Efficient Google Maps usage: less unnecessary calls to instantiate a dynamic map.
- Reaction to a [bug](https://issuetracker.google.com/issues/35821412) when removing Google Map instance
