### PR TITLE
SearchMap should use Mapbox as map provider by default

### DIFF
--- a/server/csp.js
+++ b/server/csp.js
@@ -5,6 +5,7 @@ const self = "'self'";
 const unsafeInline = "'unsafe-inline'";
 const unsafeEval = "'unsafe-eval'";
 const data = 'data:';
+const blob = 'blob:';
 const devImagesMaybe = dev ? ['*.localhost:8000'] : [];
 
 // Default CSP whitelist.
@@ -14,10 +15,13 @@ const devImagesMaybe = dev ? ['*.localhost:8000'] : [];
 const defaultDirectives = {
   baseUri: [self],
   defaultSrc: [self],
+  childSrc: [blob],
   connectSrc: [
     self,
     process.env.REACT_APP_SHARETRIBE_SDK_BASE_URL,
     'maps.googleapis.com',
+    '*.tiles.mapbox.com',
+    'api.mapbox.com',
 
     // Google Analytics
     'www.google-analytics.com',
@@ -31,6 +35,7 @@ const defaultDirectives = {
   imgSrc: [
     self,
     data,
+    blob,
     ...devImagesMaybe,
     '*.imgix.net',
     'sharetribe.imgix.net', // Safari 9.1 didn't recognize asterisk rule.
@@ -57,10 +62,11 @@ const defaultDirectives = {
     unsafeEval,
     data,
     'maps.googleapis.com',
+    'api.mapbox.com',
     '*.google-analytics.com',
     'js.stripe.com',
   ],
-  styleSrc: [self, unsafeInline, 'fonts.googleapis.com'],
+  styleSrc: [self, unsafeInline, 'fonts.googleapis.com', 'api.mapbox.com'],
 };
 
 /**

--- a/src/components/SearchMap/SearchMap.helpers.js
+++ b/src/components/SearchMap/SearchMap.helpers.js
@@ -1,0 +1,35 @@
+import groupBy from 'lodash/groupBy';
+import reduce from 'lodash/reduce';
+
+/**
+ * hasParentWithClassName searches class name from parent elements of given target
+ * @param {Node} target - element whose parent might contain given class.
+ * @param {String} className - class name string to be found
+ */
+export const hasParentWithClassName = (target, className) => {
+  return [...document.querySelectorAll(`.${className}`)].some(
+    el => el !== target && el.contains(target)
+  );
+};
+
+/**
+ * Listings array grouped by geolocation
+ * @param {Array} mapListings - listings to be grouped on map
+ * @return {Object} - Object where coordinate pair is the key to different listings
+ */
+export const groupedByCoordinates = mapListings => {
+  return groupBy(mapListings, l => {
+    const g = l.attributes.geolocation;
+    return `${g.lat}-${g.lng}`;
+  });
+};
+
+/**
+ * Listings (in location based object literal) is mapped to array
+ * @param {Object} mapListings - listings to be grouped on map
+ * @return {Array} - An array where items are arrays of listings
+ *   (They are arrays containing all the listings in that location)
+ */
+export const reducedToArray = mapListings => {
+  return reduce(mapListings, (acc, listing) => acc.concat([listing]), []);
+};

--- a/src/components/SearchMap/SearchMap.js
+++ b/src/components/SearchMap/SearchMap.js
@@ -143,7 +143,6 @@ export class SearchMapComponent extends Component {
     //   containerElement={<div className={classes} onClick={this.onMapClicked} />}
     //   mapElement={<div className={mapRootClassName || css.mapRoot} />}
     //   center={center}
-    //   isOpenOnModal={isOpenOnModal}
     //   infoCardOpen={infoCardOpen}
     //   listings={listings}
     //   activeListingId={activeListingId}
@@ -165,7 +164,6 @@ export class SearchMapComponent extends Component {
         <SearchMapWithMapbox
           className={classes}
           center={center}
-          isOpenOnModal={isOpenOnModal}
           infoCardOpen={infoCardOpen}
           listings={listings}
           activeListingId={activeListingId}

--- a/src/components/SearchMap/SearchMap.js
+++ b/src/components/SearchMap/SearchMap.js
@@ -1,80 +1,25 @@
 import React, { Component } from 'react';
 import { arrayOf, bool, func, number, string, shape } from 'prop-types';
 import { withRouter } from 'react-router-dom';
-import { withGoogleMap, GoogleMap } from 'react-google-maps';
 import classNames from 'classnames';
-import groupBy from 'lodash/groupBy';
 import isEqual from 'lodash/isEqual';
-import reduce from 'lodash/reduce';
 import routeConfiguration from '../../routeConfiguration';
 import { createResourceLocatorString } from '../../util/routes';
 import { createSlug } from '../../util/urlHelpers';
-import { types as sdkTypes } from '../../util/sdkLoader';
 import { propTypes } from '../../util/types';
 import { obfuscatedCoordinates } from '../../util/maps';
-import { googleBoundsToSDKBounds } from '../../util/googleMaps';
-import { SearchMapInfoCard, SearchMapPriceLabel, SearchMapGroupLabel } from '../../components';
 import config from '../../config';
+import { hasParentWithClassName } from './SearchMap.helpers.js';
 
+import SearchMapWithGoogleMap, {
+  LABEL_HANDLE,
+  INFO_CARD_HANDLE,
+  fitMapToBounds,
+  mapBoundsToSDKBounds,
+  isMapsLibLoaded,
+} from './SearchMapWithGoogleMap';
 import ReusableMapContainer from './ReusableMapContainer';
 import css from './SearchMap.css';
-
-const LABEL_HANDLE = 'SearchMapLabel';
-const INFO_CARD_HANDLE = 'SearchMapInfoCard';
-
-/**
- * Fit part of map (descriped with bounds) to visible map-viewport
- *
- * @param {Object} map - map that needs to be centered with given bounds
- * @param {SDK.LatLngBounds} bounds - the area that needs to be visible when map loads.
- */
-const fitMapToBounds = (map, bounds, padding) => {
-  const { ne, sw } = bounds || {};
-  // map bounds as string literal for google.maps
-  const mapBounds = bounds ? { north: ne.lat, east: ne.lng, south: sw.lat, west: sw.lng } : null;
-
-  // If bounds are given, use it (defaults to center & zoom).
-  if (map && mapBounds) {
-    if (padding == null) {
-      map.fitBounds(mapBounds);
-    } else {
-      map.fitBounds(mapBounds, padding);
-    }
-  }
-};
-
-/**
- * hasParentWithClassName searches class name from parent elements of given target
- * @param {Node} target - element whose parent might contain given class.
- * @param {String} className - class name string to be found
- */
-const hasParentWithClassName = (target, className) => {
-  return [...document.querySelectorAll(`.${className}`)].some(
-    el => el !== target && el.contains(target)
-  );
-};
-
-/**
- * Listings array grouped by geolocation
- * @param {Array} mapListings - listings to be grouped on map
- * @return {Object} - Object where coordinate pair is the key to different listings
- */
-const groupedByCoordinates = mapListings => {
-  return groupBy(mapListings, l => {
-    const g = l.attributes.geolocation;
-    return `${g.lat}-${g.lng}`;
-  });
-};
-
-/**
- * Listings (in location based object literal) is mapped to array
- * @param {Object} mapListings - listings to be grouped on map
- * @return {Array} - An array where items are arrays of listings
- *   (They are arrays containing all the listings in that location)
- */
-const reducedToArray = mapListings => {
-  return reduce(mapListings, (acc, listing) => acc.concat([listing]), []);
-};
 
 const withCoordinatesObfuscated = listings => {
   return listings.map(listing => {
@@ -91,114 +36,12 @@ const withCoordinatesObfuscated = listings => {
   });
 };
 
-/**
- * MapWithGoogleMap uses withGoogleMap HOC.
- * It handles some of the google map initialization states.
- */
-const MapWithGoogleMap = withGoogleMap(props => {
-  const {
-    activeListingId,
-    center,
-    infoCardOpen,
-    listings,
-    onIdle,
-    onListingClicked,
-    onListingInfoCardClicked,
-    createURLToListing,
-    onMapLoad,
-    zoom,
-    mapComponentRefreshToken,
-  } = props;
-
-  const listingArraysInLocations = reducedToArray(groupedByCoordinates(listings));
-  const priceLabels = listingArraysInLocations.reverse().map(listingArr => {
-    const isActive = activeListingId
-      ? !!listingArr.find(l => activeListingId.uuid === l.id.uuid)
-      : false;
-
-    // If location contains only one listing, print price label
-    if (listingArr.length === 1) {
-      const listing = listingArr[0];
-      const infoCardOpenIds = Array.isArray(infoCardOpen) ? infoCardOpen.map(l => l.id.uuid) : [];
-
-      // if the listing is open, don't print price label
-      if (infoCardOpen != null && infoCardOpenIds.includes(listing.id.uuid)) {
-        return null;
-      }
-      return (
-        <SearchMapPriceLabel
-          isActive={isActive}
-          key={listing.id.uuid}
-          className={LABEL_HANDLE}
-          listing={listing}
-          onListingClicked={onListingClicked}
-          mapComponentRefreshToken={mapComponentRefreshToken}
-        />
-      );
-    }
-    return (
-      <SearchMapGroupLabel
-        isActive={isActive}
-        key={listingArr[0].id.uuid}
-        className={LABEL_HANDLE}
-        listings={listingArr}
-        onListingClicked={onListingClicked}
-        mapComponentRefreshToken={mapComponentRefreshToken}
-      />
-    );
-  });
-
-  const listingsArray = Array.isArray(infoCardOpen) ? infoCardOpen : [infoCardOpen];
-  const openedCard = infoCardOpen ? (
-    <SearchMapInfoCard
-      key={listingsArray[0].id.uuid}
-      mapComponentRefreshToken={mapComponentRefreshToken}
-      className={INFO_CARD_HANDLE}
-      listings={listingsArray}
-      onListingInfoCardClicked={onListingInfoCardClicked}
-      createURLToListing={createURLToListing}
-    />
-  ) : null;
-
-  const controlPosition =
-    typeof window !== 'undefined' && typeof window.google !== 'undefined'
-      ? window.google.maps.ControlPosition.LEFT_TOP
-      : 5;
-
-  return (
-    <GoogleMap
-      defaultZoom={zoom}
-      defaultCenter={center}
-      options={{
-        // Disable all controls except zoom
-        mapTypeControl: false,
-        scrollwheel: false,
-        fullscreenControl: false,
-        clickableIcons: false,
-        streetViewControl: false,
-
-        // When infoCard is open, we can't differentiate double click on top of card vs map.
-        disableDoubleClickZoom: !!infoCardOpen,
-
-        zoomControlOptions: {
-          position: controlPosition,
-        },
-      }}
-      ref={onMapLoad}
-      onIdle={onIdle}
-    >
-      {priceLabels}
-      {openedCard}
-    </GoogleMap>
-  );
-});
-
 export class SearchMapComponent extends Component {
   constructor(props) {
     super(props);
 
     this.listings = [];
-    this.googleMap = null;
+    this.mapRef = null;
     this.mapReattachmentCount = 0;
     this.state = { infoCardOpen: null };
 
@@ -210,14 +53,14 @@ export class SearchMapComponent extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.googleMap) {
-      const currentBounds = googleBoundsToSDKBounds(this.googleMap.getBounds());
+    if (this.mapRef) {
+      const currentBounds = mapBoundsToSDKBounds(this.mapRef);
 
       // Do not call fitMapToBounds if bounds are the same.
       // Our bounds are viewport bounds, and fitBounds will try to add margins around those bounds
       // that would result to zoom-loop (bound change -> fitmap -> bounds change -> ...)
       if (!isEqual(nextProps.bounds, currentBounds) && nextProps.useLocationSearchBounds) {
-        fitMapToBounds(this.googleMap, nextProps.bounds, 0);
+        fitMapToBounds(this.mapRef, nextProps.bounds, 0);
       }
     }
   }
@@ -260,11 +103,11 @@ export class SearchMapComponent extends Component {
   }
 
   onMapLoadHandler(map) {
-    this.googleMap = map;
+    this.mapRef = map;
 
-    if (this.googleMap) {
+    if (this.mapRef) {
       // map is ready, let's fit search area's bounds to map's viewport
-      fitMapToBounds(this.googleMap, this.props.bounds, 0);
+      fitMapToBounds(this.mapRef, this.props.bounds, 0);
     }
   }
 
@@ -276,14 +119,12 @@ export class SearchMapComponent extends Component {
       center,
       listings: originalListings,
       mapRootClassName,
-      onCloseAsModal,
       onIdle,
       zoom,
       coordinatesConfig,
       activeListingId,
     } = this.props;
     const classes = classNames(rootClassName || css.root, className);
-    const mapClasses = mapRootClassName || css.mapRoot;
 
     const listingsWithLocation = originalListings.filter(l => !!l.attributes.geolocation);
     const listings = coordinatesConfig.fuzzy
@@ -291,39 +132,33 @@ export class SearchMapComponent extends Component {
       : listingsWithLocation;
     const infoCardOpen = this.state.infoCardOpen;
 
-    const isMapsLibLoaded = typeof window !== 'undefined' && window.google && window.google.maps;
-
     const forceUpdateHandler = () => {
       this.mapReattachmentCount += 1;
     };
 
     // container element listens clicks so that opened SearchMapInfoCard can be closed
     /* eslint-disable jsx-a11y/no-static-element-interactions */
-    return isMapsLibLoaded ? (
+    return isMapsLibLoaded() ? (
       <ReusableMapContainer className={reusableContainerClassName} onReattach={forceUpdateHandler}>
-        <MapWithGoogleMap
+        <SearchMapWithGoogleMap
           containerElement={<div className={classes} onClick={this.onMapClicked} />}
-          mapElement={<div className={mapClasses} />}
+          mapElement={<div className={mapRootClassName || css.mapRoot} />}
           center={center}
+          isOpenOnModal={isOpenOnModal}
+          infoCardOpen={infoCardOpen}
           listings={listings}
           activeListingId={activeListingId}
-          infoCardOpen={infoCardOpen}
+          mapComponentRefreshToken={this.state.mapReattachmentCount}
+          createURLToListing={this.createURLToListing}
           onListingClicked={this.onListingClicked}
           onListingInfoCardClicked={this.onListingInfoCardClicked}
-          createURLToListing={this.createURLToListing}
           onMapLoad={this.onMapLoadHandler}
           onIdle={() => {
-            if (this.googleMap) {
-              onIdle(this.googleMap);
-            }
-          }}
-          onCloseAsModal={() => {
-            if (onCloseAsModal) {
-              onCloseAsModal();
+            if (this.mapRef) {
+              onIdle(this.mapRef);
             }
           }}
           zoom={zoom}
-          mapComponentRefreshToken={this.mapReattachmentCount}
         />
       </ReusableMapContainer>
     ) : (
@@ -339,7 +174,7 @@ SearchMapComponent.defaultProps = {
   mapRootClassName: null,
   reusableContainerClassName: null,
   bounds: null,
-  center: new sdkTypes.LatLng(0, 0),
+  center: null,
   activeListingId: null,
   listings: [],
   onCloseAsModal: null,

--- a/src/components/SearchMap/SearchMap.js
+++ b/src/components/SearchMap/SearchMap.js
@@ -11,14 +11,14 @@ import { obfuscatedCoordinates } from '../../util/maps';
 import config from '../../config';
 import { hasParentWithClassName } from './SearchMap.helpers.js';
 
-import SearchMapWithGoogleMap, {
+import SearchMapWithMapbox, {
   LABEL_HANDLE,
   INFO_CARD_HANDLE,
   getMapBounds,
   getMapCenter,
   fitMapToBounds,
   isMapsLibLoaded,
-} from './SearchMapWithGoogleMap';
+} from './SearchMapWithMapbox';
 import ReusableMapContainer from './ReusableMapContainer';
 import css from './SearchMap.css';
 
@@ -119,7 +119,6 @@ export class SearchMapComponent extends Component {
       reusableContainerClassName,
       center,
       listings: originalListings,
-      mapRootClassName,
       onIdle,
       zoom,
       coordinatesConfig,
@@ -137,13 +136,34 @@ export class SearchMapComponent extends Component {
       this.mapReattachmentCount += 1;
     };
 
-    // container element listens clicks so that opened SearchMapInfoCard can be closed
-    /* eslint-disable jsx-a11y/no-static-element-interactions */
+    // Using Google Maps as map provider should use following component
+    // instead of SearchMapWithMapbox:
+    //
+    // <SearchMapWithGoogleMap
+    //   containerElement={<div className={classes} onClick={this.onMapClicked} />}
+    //   mapElement={<div className={mapRootClassName || css.mapRoot} />}
+    //   center={center}
+    //   isOpenOnModal={isOpenOnModal}
+    //   infoCardOpen={infoCardOpen}
+    //   listings={listings}
+    //   activeListingId={activeListingId}
+    //   mapComponentRefreshToken={this.state.mapReattachmentCount}
+    //   createURLToListing={this.createURLToListing}
+    //   onListingClicked={this.onListingClicked}
+    //   onListingInfoCardClicked={this.onListingInfoCardClicked}
+    //   onMapLoad={this.onMapLoadHandler}
+    //   onIdle={() => {
+    //     if (this.mapRef) {
+    //       onIdle(this.mapRef);
+    //     }
+    //   }}
+    //   zoom={zoom}
+    // />
+
     return isMapsLibLoaded() ? (
       <ReusableMapContainer className={reusableContainerClassName} onReattach={forceUpdateHandler}>
-        <SearchMapWithGoogleMap
-          containerElement={<div className={classes} onClick={this.onMapClicked} />}
-          mapElement={<div className={mapRootClassName || css.mapRoot} />}
+        <SearchMapWithMapbox
+          className={classes}
           center={center}
           isOpenOnModal={isOpenOnModal}
           infoCardOpen={infoCardOpen}
@@ -154,6 +174,7 @@ export class SearchMapComponent extends Component {
           onListingClicked={this.onListingClicked}
           onListingInfoCardClicked={this.onListingInfoCardClicked}
           onMapLoad={this.onMapLoadHandler}
+          onClick={this.onMapClicked}
           onIdle={() => {
             if (this.mapRef) {
               onIdle(this.mapRef);
@@ -165,7 +186,6 @@ export class SearchMapComponent extends Component {
     ) : (
       <div className={classes} />
     );
-    /* eslint-enable jsx-a11y/no-static-element-interactions */
   }
 }
 

--- a/src/components/SearchMap/SearchMap.js
+++ b/src/components/SearchMap/SearchMap.js
@@ -14,8 +14,9 @@ import { hasParentWithClassName } from './SearchMap.helpers.js';
 import SearchMapWithGoogleMap, {
   LABEL_HANDLE,
   INFO_CARD_HANDLE,
+  getMapBounds,
+  getMapCenter,
   fitMapToBounds,
-  mapBoundsToSDKBounds,
   isMapsLibLoaded,
 } from './SearchMapWithGoogleMap';
 import ReusableMapContainer from './ReusableMapContainer';
@@ -54,7 +55,7 @@ export class SearchMapComponent extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.mapRef) {
-      const currentBounds = mapBoundsToSDKBounds(this.mapRef);
+      const currentBounds = getMapBounds(this.mapRef);
 
       // Do not call fitMapToBounds if bounds are the same.
       // Our bounds are viewport bounds, and fitBounds will try to add margins around those bounds
@@ -207,5 +208,8 @@ SearchMapComponent.propTypes = {
 };
 
 const SearchMap = withRouter(SearchMapComponent);
+
+SearchMap.getMapBounds = getMapBounds;
+SearchMap.getMapCenter = getMapCenter;
 
 export default SearchMap;

--- a/src/components/SearchMap/SearchMapWithGoogleMap.js
+++ b/src/components/SearchMap/SearchMapWithGoogleMap.js
@@ -242,21 +242,19 @@ const MapWithGoogleMap = withGoogleMap(props => {
       defaultZoom={zoom}
       defaultCenter={center}
       options={{
-        // Disable map type (ie. Satellite etc.)
+        // Disable all controls except zoom
         mapTypeControl: false,
-        // Disable zooming by scrolling
         scrollwheel: false,
-        // Disable fullscreen control: this won't work with mobile close-modal button
-        // since they are on top of each others.
-        fullscreenControl: !isOpenOnModal,
-        // Click disabled for point-of-interests
+        fullscreenControl: false,
         clickableIcons: false,
+        streetViewControl: false,
+
         // When infoCard is open, we can't differentiate double click on top of card vs map.
         disableDoubleClickZoom: !!infoCardOpen,
+
         zoomControlOptions: {
           position: controlPosition,
         },
-        streetViewControl: false,
       }}
       ref={onMapLoad}
       onIdle={onIdle}
@@ -269,7 +267,6 @@ const MapWithGoogleMap = withGoogleMap(props => {
 
 MapWithGoogleMap.defaultProps = {
   center: new sdkTypes.LatLng(0, 0),
-  isOpenOnModal: false,
   infoCardOpen: null,
   // priceLabels: [],
   // infoCard: null,
@@ -281,7 +278,6 @@ MapWithGoogleMap.defaultProps = {
 MapWithGoogleMap.propTypes = {
   center: propTypes.latlng,
   infoCardOpen: oneOfType([propTypes.listing, arrayOf(propTypes.listing)]),
-  isOpenOnModal: bool,
   // priceLabels: arrayOf(node),
   // infoCard: node,
   listings: arrayOf(propTypes.listing),

--- a/src/components/SearchMap/SearchMapWithGoogleMap.js
+++ b/src/components/SearchMap/SearchMapWithGoogleMap.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { arrayOf, bool, func, number, oneOfType } from 'prop-types';
 import { withGoogleMap, GoogleMap, OverlayView } from 'react-google-maps';
 import { OVERLAY_VIEW } from 'react-google-maps/lib/constants';
-import { googleBoundsToSDKBounds } from '../../util/googleMaps';
 import { types as sdkTypes } from '../../util/sdkLoader';
 import { propTypes } from '../../util/types';
 import { ensureListing } from '../../util/data';
@@ -35,11 +34,34 @@ export const fitMapToBounds = (map, bounds, padding) => {
 };
 
 /**
- * Convert current map's bounds object to Flex SDK bounds
+ * Convert Google formatted LatLng object to Sharetribe SDK's LatLng coordinate format
+ *
+ * @param {LatLng} googleLatLng - Google Maps LatLng
+ *
+ * @return {SDKLatLng} - Converted latLng coordinate
  */
-export const mapBoundsToSDKBounds = map => {
-  return googleBoundsToSDKBounds(map.getBounds());
+export const googleLatLngToSDKLatLng = googleLatLng => {
+  return new SDKLatLng(googleLatLng.lat(), googleLatLng.lng());
 };
+
+/**
+ * Convert Google formatted bounds object to Sharetribe SDK's bounds format
+ *
+ * @param {LatLngBounds} googleBounds - Google Maps LatLngBounds
+ *
+ * @return {SDKLatLngBounds} - Converted bounds
+ */
+export const googleBoundsToSDKBounds = googleBounds => {
+  if (!googleBounds) {
+    return null;
+  }
+  const ne = googleBounds.getNorthEast();
+  const sw = googleBounds.getSouthWest();
+  return new SDKLatLngBounds(new SDKLatLng(ne.lat(), ne.lng()), new SDKLatLng(sw.lat(), sw.lng()));
+};
+
+export const getMapBounds = map => googleBoundsToSDKBounds(map.getBounds());
+export const getMapCenter = map => googleLatLngToSDKLatLng(map.getCenter());
 
 /**
  * Check if map library is loaded
@@ -176,7 +198,6 @@ const infoCardComponent = (
   );
 };
 
-
 /**
  * MapWithGoogleMap uses withGoogleMap HOC.
  * It handles some of the google map initialization states.
@@ -207,7 +228,7 @@ const MapWithGoogleMap = withGoogleMap(props => {
     activeListingId,
     infoCardOpen,
     onListingClicked,
-    mapComponentRefreshToken,
+    mapComponentRefreshToken
   );
   const infoCard = infoCardComponent(
     infoCardOpen,

--- a/src/components/SearchMap/SearchMapWithGoogleMap.js
+++ b/src/components/SearchMap/SearchMapWithGoogleMap.js
@@ -1,0 +1,274 @@
+import React from 'react';
+import { arrayOf, bool, func, number, oneOfType } from 'prop-types';
+import { withGoogleMap, GoogleMap, OverlayView } from 'react-google-maps';
+import { OVERLAY_VIEW } from 'react-google-maps/lib/constants';
+import { googleBoundsToSDKBounds } from '../../util/googleMaps';
+import { types as sdkTypes } from '../../util/sdkLoader';
+import { propTypes } from '../../util/types';
+import { ensureListing } from '../../util/data';
+import { SearchMapInfoCard, SearchMapPriceLabel, SearchMapGroupLabel } from '../../components';
+
+import { groupedByCoordinates, reducedToArray } from './SearchMap.helpers.js';
+
+export const LABEL_HANDLE = 'SearchMapLabel';
+export const INFO_CARD_HANDLE = 'SearchMapInfoCard';
+
+/**
+ * Fit part of map (descriped with bounds) to visible map-viewport
+ *
+ * @param {Object} map - map that needs to be centered with given bounds
+ * @param {SDK.LatLngBounds} bounds - the area that needs to be visible when map loads.
+ */
+export const fitMapToBounds = (map, bounds, padding) => {
+  const { ne, sw } = bounds || {};
+  // map bounds as string literal for google.maps
+  const mapBounds = bounds ? { north: ne.lat, east: ne.lng, south: sw.lat, west: sw.lng } : null;
+
+  // If bounds are given, use it (defaults to center & zoom).
+  if (map && mapBounds) {
+    if (padding == null) {
+      map.fitBounds(mapBounds);
+    } else {
+      map.fitBounds(mapBounds, padding);
+    }
+  }
+};
+
+/**
+ * Convert current map's bounds object to Flex SDK bounds
+ */
+export const mapBoundsToSDKBounds = map => {
+  return googleBoundsToSDKBounds(map.getBounds());
+};
+
+/**
+ * Check if map library is loaded
+ */
+export const isMapsLibLoaded = () =>
+  typeof window !== 'undefined' && window.google && window.google.maps;
+
+/**
+ * FIX "TypeError: Cannot read property 'overlayMouseTarget' of null"
+ * Override draw function to catch errors with map panes being undefined to prevent console errors
+ * https://github.com/tomchentw/react-google-maps/issues/482
+ */
+class CustomOverlayView extends OverlayView {
+  draw() {
+    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapPanes
+    const mapPanes = this.state[OVERLAY_VIEW].getPanes();
+    // Add conditional to ensure panes and container exist before drawing
+    if (mapPanes && this.containerElement) {
+      super.draw();
+    }
+  }
+}
+
+/**
+ * Center label so that caret is pointing to correct pixel.
+ * (vertical positioning: height + arrow)
+ */
+const getPixelPositionOffset = (width, height) => {
+  return { x: -1 * (width / 2), y: -1 * (height + 3) };
+};
+
+const priceLabelsInLocations = (
+  listings,
+  activeListingId,
+  infoCardOpen,
+  onListingClicked,
+  mapComponentRefreshToken
+) => {
+  const listingArraysInLocations = reducedToArray(groupedByCoordinates(listings));
+  const priceLabels = listingArraysInLocations.reverse().map(listingArr => {
+    const isActive = activeListingId
+      ? !!listingArr.find(l => activeListingId.uuid === l.id.uuid)
+      : false;
+
+    // If location contains only one listing, print price label
+    if (listingArr.length === 1) {
+      const listing = listingArr[0];
+      const infoCardOpenIds = Array.isArray(infoCardOpen) ? infoCardOpen.map(l => l.id.uuid) : [];
+
+      // if the listing is open, don't print price label
+      if (infoCardOpen != null && infoCardOpenIds.includes(listing.id.uuid)) {
+        return null;
+      }
+
+      // Explicit type change to object literal for Google OverlayViews (geolocation is SDK type)
+      const { geolocation } = listing.attributes;
+      const latLngLiteral = { lat: geolocation.lat, lng: geolocation.lng };
+
+      return (
+        <CustomOverlayView
+          key={listing.id.uuid}
+          position={latLngLiteral}
+          mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
+          getPixelPositionOffset={getPixelPositionOffset}
+        >
+          <SearchMapPriceLabel
+            isActive={isActive}
+            className={LABEL_HANDLE}
+            listing={listing}
+            onListingClicked={onListingClicked}
+            mapComponentRefreshToken={mapComponentRefreshToken}
+          />
+        </CustomOverlayView>
+      );
+    }
+
+    // Explicit type change to object literal for Google OverlayViews (geolocation is SDK type)
+    const firstListing = ensureListing(listings[0]);
+    const geolocation = firstListing.attributes.geolocation;
+    const latLngLiteral = { lat: geolocation.lat, lng: geolocation.lng };
+
+    return (
+      <CustomOverlayView
+        key={listingArr[0].id.uuid}
+        position={latLngLiteral}
+        mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
+        getPixelPositionOffset={getPixelPositionOffset}
+      >
+        <SearchMapGroupLabel
+          isActive={isActive}
+          className={LABEL_HANDLE}
+          listings={listingArr}
+          onListingClicked={onListingClicked}
+          mapComponentRefreshToken={mapComponentRefreshToken}
+        />
+      </CustomOverlayView>
+    );
+  });
+  return priceLabels;
+};
+
+const infoCardComponent = (
+  infoCardOpen,
+  onListingInfoCardClicked,
+  createURLToListing,
+  mapComponentRefreshToken
+) => {
+  const listingsArray = Array.isArray(infoCardOpen) ? infoCardOpen : [infoCardOpen];
+
+  if (!infoCardOpen) {
+    return null;
+  }
+  // Explicit type change to object literal for Google OverlayViews (geolocation is SDK type)
+  const firstListing = ensureListing(listingsArray[0]);
+  const geolocation = firstListing.attributes.geolocation;
+  const latLngLiteral = { lat: geolocation.lat, lng: geolocation.lng };
+
+  return (
+    <CustomOverlayView
+      key={listingsArray[0].id.uuid}
+      position={latLngLiteral}
+      mapPaneName={OverlayView.FLOAT_PANE}
+      getPixelPositionOffset={getPixelPositionOffset}
+      styles={{ zIndex: 1 }}
+    >
+      <SearchMapInfoCard
+        mapComponentRefreshToken={mapComponentRefreshToken}
+        className={INFO_CARD_HANDLE}
+        listings={listingsArray}
+        onListingInfoCardClicked={onListingInfoCardClicked}
+        createURLToListing={createURLToListing}
+      />
+    </CustomOverlayView>
+  );
+};
+
+
+/**
+ * MapWithGoogleMap uses withGoogleMap HOC.
+ * It handles some of the google map initialization states.
+ */
+const MapWithGoogleMap = withGoogleMap(props => {
+  const {
+    center,
+    infoCardOpen,
+    isOpenOnModal,
+    listings,
+    activeListingId,
+    createURLToListing,
+    onListingClicked,
+    onListingInfoCardClicked,
+    onIdle,
+    onMapLoad,
+    zoom,
+    mapComponentRefreshToken,
+  } = props;
+
+  const controlPosition =
+    typeof window !== 'undefined' && typeof window.google !== 'undefined'
+      ? window.google.maps.ControlPosition.LEFT_TOP
+      : 5;
+
+  const priceLabels = priceLabelsInLocations(
+    listings,
+    activeListingId,
+    infoCardOpen,
+    onListingClicked,
+    mapComponentRefreshToken,
+  );
+  const infoCard = infoCardComponent(
+    infoCardOpen,
+    onListingInfoCardClicked,
+    createURLToListing,
+    mapComponentRefreshToken
+  );
+
+  return (
+    <GoogleMap
+      defaultZoom={zoom}
+      defaultCenter={center}
+      options={{
+        // Disable map type (ie. Satellite etc.)
+        mapTypeControl: false,
+        // Disable zooming by scrolling
+        scrollwheel: false,
+        // Disable fullscreen control: this won't work with mobile close-modal button
+        // since they are on top of each others.
+        fullscreenControl: !isOpenOnModal,
+        // Click disabled for point-of-interests
+        clickableIcons: false,
+        // When infoCard is open, we can't differentiate double click on top of card vs map.
+        disableDoubleClickZoom: !!infoCardOpen,
+        zoomControlOptions: {
+          position: controlPosition,
+        },
+        streetViewControl: false,
+      }}
+      ref={onMapLoad}
+      onIdle={onIdle}
+    >
+      {priceLabels}
+      {infoCard}
+    </GoogleMap>
+  );
+});
+
+MapWithGoogleMap.defaultProps = {
+  center: new sdkTypes.LatLng(0, 0),
+  isOpenOnModal: false,
+  infoCardOpen: null,
+  // priceLabels: [],
+  // infoCard: null,
+  listings: [],
+  activeListingId: null,
+  zoom: 11,
+};
+
+MapWithGoogleMap.propTypes = {
+  center: propTypes.latlng,
+  infoCardOpen: oneOfType([propTypes.listing, arrayOf(propTypes.listing)]),
+  isOpenOnModal: bool,
+  // priceLabels: arrayOf(node),
+  // infoCard: node,
+  listings: arrayOf(propTypes.listing),
+  activeListingId: propTypes.uuid,
+
+  onIdle: func.isRequired,
+  onMapLoad: func.isRequired,
+  zoom: number,
+};
+
+export default MapWithGoogleMap;

--- a/src/components/SearchMap/SearchMapWithMapbox.css
+++ b/src/components/SearchMap/SearchMapWithMapbox.css
@@ -1,0 +1,25 @@
+.fullArea {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
+.activeLabel {
+  z-index: 1;
+}
+
+.labelContainer {
+  &:hover {
+    z-index: 1;
+  }
+
+  &:focus {
+    outline: none;
+  }
+}
+
+.infoCardContainer {
+  z-index: 1;
+}

--- a/src/components/SearchMap/SearchMapWithMapbox.js
+++ b/src/components/SearchMap/SearchMapWithMapbox.js
@@ -227,6 +227,9 @@ class SearchMapWithMapbox extends Component {
       scrollZoom: false,
     });
 
+    var nav = new window.mapboxgl.NavigationControl({ showCompass: false });
+    this.map.addControl(nav, 'top-left');
+
     this.map.on('moveend', this.props.onIdle);
   }
 

--- a/src/components/SearchMap/SearchMapWithMapbox.js
+++ b/src/components/SearchMap/SearchMapWithMapbox.js
@@ -39,13 +39,22 @@ export const fitMapToBounds = (map, bounds, padding) => {
 
 /**
  * Convert Mapbox formatted LatLng object to Sharetribe SDK's LatLng coordinate format
+ * Longitudes > 180 and < -180 are converted to the correct corresponding value
+ * between -180 and 180.
  *
  * @param {LngLat} mapboxLngLat - Mapbox LngLat
  *
  * @return {SDKLatLng} - Converted latLng coordinate
  */
 export const mapboxLngLatToSDKLatLng = lngLat => {
-  return new SDKLatLng(lngLat.lat, lngLat.lng);
+  const mapboxLng = lngLat.lng;
+
+  // For bounding boxes that overlap the antimeridian Mapbox sometimes gives
+  // longitude values outside -180 and 180 degrees.Those values are converted
+  // so that longitude is always between -180 and 180.
+  const lng = mapboxLng > 180 ? mapboxLng - 360 : mapboxLng < -180 ? mapboxLng + 360 : mapboxLng;
+
+  return new SDKLatLng(lngLat.lat, lng);
 };
 
 /**

--- a/src/components/SearchMap/SearchMapWithMapbox.js
+++ b/src/components/SearchMap/SearchMapWithMapbox.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
-import { arrayOf, bool, func, node, number } from 'prop-types';
+import { arrayOf, func, node, number } from 'prop-types';
 import differenceBy from 'lodash/differenceBy';
 import classNames from 'classnames';
 import { types as sdkTypes } from '../../util/sdkLoader';
@@ -352,7 +352,6 @@ class SearchMapWithMapbox extends Component {
 
 SearchMapWithMapbox.defaultProps = {
   center: null,
-  isOpenOnModal: false,
   priceLabels: [],
   infoCard: null,
   zoom: 11,
@@ -360,7 +359,6 @@ SearchMapWithMapbox.defaultProps = {
 
 SearchMapWithMapbox.propTypes = {
   center: propTypes.latlng,
-  isOpenOnModal: bool,
   priceLabels: arrayOf(node),
   infoCard: node,
   onClick: func.isRequired,

--- a/src/components/SearchMap/SearchMapWithMapbox.js
+++ b/src/components/SearchMap/SearchMapWithMapbox.js
@@ -1,0 +1,372 @@
+import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
+import { arrayOf, bool, func, node, number } from 'prop-types';
+import differenceBy from 'lodash/differenceBy';
+import classNames from 'classnames';
+import { types as sdkTypes } from '../../util/sdkLoader';
+import { propTypes } from '../../util/types';
+import { ensureListing } from '../../util/data';
+import { SearchMapInfoCard, SearchMapPriceLabel, SearchMapGroupLabel } from '../../components';
+
+import { groupedByCoordinates, reducedToArray } from './SearchMap.helpers.js';
+import css from './SearchMapWithMapbox.css';
+
+export const LABEL_HANDLE = 'SearchMapLabel';
+export const INFO_CARD_HANDLE = 'SearchMapInfoCard';
+
+const { LatLng: SDKLatLng, LatLngBounds: SDKLatLngBounds } = sdkTypes;
+
+/**
+ * Fit part of map (descriped with bounds) to visible map-viewport
+ *
+ * @param {Object} map - map that needs to be centered with given bounds
+ * @param {SDK.LatLngBounds} bounds - the area that needs to be visible when map loads.
+ */
+export const fitMapToBounds = (map, bounds, padding) => {
+  const { ne, sw } = bounds || {};
+  // map bounds as string literal for google.maps
+  const mapBounds = bounds ? [[sw.lng, sw.lat], [ne.lng, ne.lat]] : null;
+
+  // If bounds are given, use it (defaults to center & zoom).
+  if (map && mapBounds) {
+    if (padding == null) {
+      map.fitBounds(mapBounds);
+    } else {
+      map.fitBounds(mapBounds, { padding, linear: true });
+    }
+  }
+};
+
+/**
+ * Convert Mapbox formatted LatLng object to Sharetribe SDK's LatLng coordinate format
+ *
+ * @param {LngLat} mapboxLngLat - Mapbox LngLat
+ *
+ * @return {SDKLatLng} - Converted latLng coordinate
+ */
+export const mapboxLngLatToSDKLatLng = lngLat => {
+  return new SDKLatLng(lngLat.lat, lngLat.lng);
+};
+
+/**
+ * Convert Mapbox formatted bounds object to Sharetribe SDK's bounds format
+ *
+ * @param {LngLatBounds} mapboxBounds - Mapbox LngLatBounds
+ *
+ * @return {SDKLatLngBounds} - Converted bounds
+ */
+export const mapboxBoundsToSDKBounds = mapboxBounds => {
+  if (!mapboxBounds) {
+    return null;
+  }
+
+  const ne = mapboxBounds.getNorthEast();
+  const sw = mapboxBounds.getSouthWest();
+  return new SDKLatLngBounds(mapboxLngLatToSDKLatLng(ne), mapboxLngLatToSDKLatLng(sw));
+};
+
+/**
+ * Return map bounds as SDKBounds
+ *
+ * @param {Mapbox} map - Mapbox map from where the bounds are asked
+ *
+ * @return {SDKLatLngBounds} - Converted bounds of given map
+ */
+export const getMapBounds = map => mapboxBoundsToSDKBounds(map.getBounds());
+
+/**
+ * Return map center as SDKLatLng
+ *
+ * @param {Mapbox} map - Mapbox map from where the center is asked
+ *
+ * @return {SDKLatLng} - Converted center of given map
+ */
+export const getMapCenter = map => mapboxLngLatToSDKLatLng(map.getCenter());
+
+/**
+ * Check if map library is loaded
+ */
+export const isMapsLibLoaded = () =>
+  typeof window !== 'undefined' && window.mapboxgl && window.mapboxgl.accessToken;
+
+/**
+ * Return price labels grouped by listing locations.
+ * This is a helper function for SearchMapWithMapbox component.
+ */
+const priceLabelsInLocations = (
+  listings,
+  activeListingId,
+  infoCardOpen,
+  onListingClicked,
+  mapComponentRefreshToken
+) => {
+  const listingArraysInLocations = reducedToArray(groupedByCoordinates(listings));
+  const priceLabels = listingArraysInLocations.reverse().map(listingArr => {
+    const isActive = activeListingId
+      ? !!listingArr.find(l => activeListingId.uuid === l.id.uuid)
+      : false;
+
+    // If location contains only one listing, print price label
+    if (listingArr.length === 1) {
+      const listing = listingArr[0];
+      const infoCardOpenIds = Array.isArray(infoCardOpen)
+        ? infoCardOpen.map(l => l.id.uuid)
+        : infoCardOpen
+          ? [infoCardOpen.id.uuid]
+          : [];
+
+      // if the listing is open, don't print price label
+      if (infoCardOpen != null && infoCardOpenIds.includes(listing.id.uuid)) {
+        return null;
+      }
+
+      // Explicit type change to object literal for Google OverlayViews (geolocation is SDK type)
+      const { geolocation } = listing.attributes;
+
+      const key = listing.id.uuid;
+      return {
+        markerId: `price_${key}`,
+        location: geolocation,
+        type: 'price',
+        componentProps: {
+          key,
+          isActive,
+          className: LABEL_HANDLE,
+          listing,
+          onListingClicked,
+          mapComponentRefreshToken,
+        },
+      };
+    }
+
+    // Explicit type change to object literal for Google OverlayViews (geolocation is SDK type)
+    const firstListing = ensureListing(listingArr[0]);
+    const geolocation = firstListing.attributes.geolocation;
+
+    const key = listingArr[0].id.uuid;
+    return {
+      markerId: `group_${key}`,
+      location: geolocation,
+      type: 'group',
+      componentProps: {
+        key,
+        isActive,
+        className: LABEL_HANDLE,
+        listings: listingArr,
+        onListingClicked,
+        mapComponentRefreshToken,
+      },
+    };
+  });
+  return priceLabels;
+};
+
+/**
+ * Return info card. This is a helper function for SearchMapWithMapbox component.
+ */
+const infoCardComponent = (
+  infoCardOpen,
+  onListingInfoCardClicked,
+  createURLToListing,
+  mapComponentRefreshToken
+) => {
+  const listingsArray = Array.isArray(infoCardOpen) ? infoCardOpen : [infoCardOpen];
+
+  if (!infoCardOpen) {
+    return null;
+  }
+
+  const firstListing = ensureListing(listingsArray[0]);
+  const key = firstListing.id.uuid;
+  const geolocation = firstListing.attributes.geolocation;
+
+  return {
+    markerId: `infoCard_${key}`,
+    location: geolocation,
+    componentProps: {
+      key,
+      mapComponentRefreshToken,
+      className: INFO_CARD_HANDLE,
+      listings: listingsArray,
+      onListingInfoCardClicked,
+      createURLToListing,
+    },
+  };
+};
+
+/**
+ * SearchMap component using Mapbox as map provider
+ */
+class SearchMapWithMapbox extends Component {
+  constructor(props) {
+    super(props);
+    this.map = null;
+    this.currentMarkers = [];
+
+    this.onMount = this.onMount.bind(this);
+    this.initializeMap = this.initializeMap.bind(this);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!this.map) {
+      this.initializeMap();
+
+      /* Notify parent component that Mapbox map is loaded */
+      this.props.onMapLoad(this.map);
+    }
+  }
+
+  onMount(element) {
+    this.mapContainer = element;
+  }
+
+  initializeMap() {
+    this.map = new window.mapboxgl.Map({
+      container: this.mapContainer,
+      style: 'mapbox://styles/mapbox/streets-v10',
+      scrollZoom: false,
+    });
+
+    this.map.on('moveend', this.props.onIdle);
+  }
+
+  render() {
+    const {
+      className,
+      listings,
+      activeListingId,
+      infoCardOpen,
+      onListingClicked,
+      onListingInfoCardClicked,
+      createURLToListing,
+      mapComponentRefreshToken,
+    } = this.props;
+
+    if (this.map) {
+      // Create markers out of price labels and grouped labels
+      const labels = priceLabelsInLocations(
+        listings,
+        activeListingId,
+        infoCardOpen,
+        onListingClicked,
+        mapComponentRefreshToken
+      );
+
+      // If map has moved or info card opened, unnecessary markers need to be removed
+      const removableMarkers = differenceBy(this.currentMarkers, labels, 'markerId');
+      removableMarkers.forEach(rm => rm.marker.remove());
+
+      // Helper function to create markers to given container
+      const createMarker = (data, markerContainer) =>
+        new window.mapboxgl.Marker(markerContainer, { anchor: 'bottom' })
+          .setLngLat([data.location.lng, data.location.lat])
+          .addTo(this.map);
+
+      // SearchMapPriceLabel and SearchMapGroupLabel:
+      // create a new marker or use existing one if markerId is among previously rendered markers
+      this.currentMarkers = labels.filter(v => v != null).map(m => {
+        const existingMarkerId = this.currentMarkers.findIndex(
+          marker => m.markerId === marker.markerId && marker.marker
+        );
+
+        if (existingMarkerId >= 0) {
+          const { marker, markerContainer, ...rest } = this.currentMarkers[existingMarkerId];
+          return { ...rest, ...m, markerContainer, marker };
+        } else {
+          const markerContainer = document.createElement('div');
+          markerContainer.setAttribute('id', m.markerId);
+          markerContainer.classList.add(css.labelContainer);
+          const marker = createMarker(m, markerContainer);
+          return { ...m, markerContainer, marker };
+        }
+      });
+
+      /* Create marker for SearchMapInfoCard component */
+      if (infoCardOpen) {
+        const infoCard = infoCardComponent(
+          infoCardOpen,
+          onListingInfoCardClicked,
+          createURLToListing,
+          mapComponentRefreshToken
+        );
+
+        // marker container and its styles
+        const infoCardContainer = document.createElement('div');
+        infoCardContainer.setAttribute('id', infoCard.markerId);
+        infoCardContainer.classList.add(css.infoCardContainer);
+
+        this.currentInfoCard = {
+          ...infoCard,
+          markerContainer: infoCardContainer,
+          marker: infoCard ? createMarker(infoCard, infoCardContainer) : null,
+        };
+      } else {
+        this.currentInfoCard = null;
+      }
+    }
+
+    return (
+      <div
+        id="map"
+        ref={this.onMount}
+        className={classNames(className, css.fullArea)}
+        onClick={this.props.onClick}
+      >
+        {this.currentMarkers.map(m => {
+          // Remove existing activeLabel classes and add it only to the correct container
+          m.markerContainer.classList.remove(css.activeLabel);
+          if (activeListingId && activeListingId.uuid === m.componentProps.key) {
+            m.markerContainer.classList.add(css.activeLabel);
+          }
+
+          const isMapReadyForMarkers = this.map && m.markerContainer;
+          // DOM node that should be used as portal's root
+          const portalDOMContainer = isMapReadyForMarkers
+            ? document.getElementById(m.markerContainer.id)
+            : null;
+
+          // Create component portals for correct marker containers
+          if (isMapReadyForMarkers && m.type === 'price') {
+            return ReactDOM.createPortal(
+              <SearchMapPriceLabel {...m.componentProps} />,
+              portalDOMContainer
+            );
+          } else if (isMapReadyForMarkers && m.type === 'group') {
+            return ReactDOM.createPortal(
+              <SearchMapGroupLabel {...m.componentProps} />,
+              portalDOMContainer
+            );
+          }
+          return null;
+        })}
+        {this.mapContainer && this.currentInfoCard
+          ? ReactDOM.createPortal(
+              <SearchMapInfoCard {...this.currentInfoCard.componentProps} />,
+              this.currentInfoCard.markerContainer
+            )
+          : null}
+      </div>
+    );
+  }
+}
+
+SearchMapWithMapbox.defaultProps = {
+  center: null,
+  isOpenOnModal: false,
+  priceLabels: [],
+  infoCard: null,
+  zoom: 11,
+};
+
+SearchMapWithMapbox.propTypes = {
+  center: propTypes.latlng,
+  isOpenOnModal: bool,
+  priceLabels: arrayOf(node),
+  infoCard: node,
+  onClick: func.isRequired,
+  onIdle: func.isRequired,
+  onMapLoad: func.isRequired,
+  zoom: number,
+};
+
+export default SearchMapWithMapbox;

--- a/src/components/SearchMapGroupLabel/SearchMapGroupLabel.js
+++ b/src/components/SearchMapGroupLabel/SearchMapGroupLabel.js
@@ -1,32 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { OverlayView } from 'react-google-maps';
-import { OVERLAY_VIEW } from 'react-google-maps/lib/constants';
 import classNames from 'classnames';
 import { propTypes } from '../../util/types';
-import { ensureListing } from '../../util/data';
 
 import css from './SearchMapGroupLabel.css';
-
-// FIX "TypeError: Cannot read property 'overlayMouseTarget' of null"
-// Override draw function to catch errors with map panes being undefined to prevent console errors
-// https://github.com/tomchentw/react-google-maps/issues/482
-class CustomOverlayView extends OverlayView {
-  draw() {
-    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapPanes
-    const mapPanes = this.state[OVERLAY_VIEW].getPanes();
-    // Add conditional to ensure panes and container exist before drawing
-    if (mapPanes && this.containerElement) {
-      super.draw();
-    }
-  }
-}
-
-// Center label so that caret is pointing to correct pixel.
-// (vertical positioning: height + arrow) */
-const getPixelPositionOffset = (width, height) => {
-  return { x: -1 * (width / 2), y: -1 * (height + 3) };
-};
 
 class SearchMapGroupLabel extends Component {
   shouldComponentUpdate(nextProps) {
@@ -38,27 +15,16 @@ class SearchMapGroupLabel extends Component {
 
   render() {
     const { className, rootClassName, listings, onListingClicked, isActive } = this.props;
-    const firstListing = ensureListing(listings[0]);
-    const geolocation = firstListing.attributes.geolocation;
-
-    // Explicit type change to object literal for Google OverlayViews (geolocation is SDK type)
-    const latLngLiteral = { lat: geolocation.lat, lng: geolocation.lng };
     const classes = classNames(rootClassName || css.root, className);
     const countLabelClasses = classNames(css.details, { [css.detailsActive]: isActive });
     const caretClasses = classNames(css.caret, { [css.caretActive]: isActive });
 
     return (
-      <CustomOverlayView
-        position={latLngLiteral}
-        mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
-        getPixelPositionOffset={getPixelPositionOffset}
-      >
-        <button className={classes} onClick={() => onListingClicked(listings)}>
-          <div className={css.caretShadow} />
-          <div className={countLabelClasses}>{listings.length}</div>
-          <div className={caretClasses} />
-        </button>
-      </CustomOverlayView>
+      <button className={classes} onClick={() => onListingClicked(listings)}>
+        <div className={css.caretShadow} />
+        <div className={countLabelClasses}>{listings.length}</div>
+        <div className={caretClasses} />
+      </button>
     );
   }
 }

--- a/src/components/SearchMapInfoCard/SearchMapInfoCard.js
+++ b/src/components/SearchMapInfoCard/SearchMapInfoCard.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 import { arrayOf, bool, func, string } from 'prop-types';
-import { OverlayView } from 'react-google-maps';
-import { OVERLAY_VIEW } from 'react-google-maps/lib/constants';
 import { compose } from 'redux';
 import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames';
@@ -12,26 +10,6 @@ import { ensureListing } from '../../util/data';
 import { ResponsiveImage } from '../../components';
 
 import css from './SearchMapInfoCard.css';
-
-// FIX "TypeError: Cannot read property 'overlayMouseTarget' of null"
-// Override draw function to catch errors with map panes being undefined to prevent console errors
-// https://github.com/tomchentw/react-google-maps/issues/482
-class CustomOverlayView extends OverlayView {
-  draw() {
-    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapPanes
-    const mapPanes = this.state[OVERLAY_VIEW].getPanes();
-    // Add conditional to ensure panes and container exist before drawing
-    if (mapPanes && this.containerElement) {
-      super.draw();
-    }
-  }
-}
-
-// Center label so that caret is pointing to correct pixel.
-// (vertical positioning: height + arrow) */
-const getPixelPositionOffset = (width, height) => {
-  return { x: -1 * (width / 2), y: -1 * (height + 3) };
-};
 
 // ListingCard is the listing info without overlayview or carousel controls
 const ListingCard = props => {
@@ -116,10 +94,6 @@ class SearchMapInfoCard extends Component {
       onListingInfoCardClicked,
     } = this.props;
     const currentListing = ensureListing(listings[this.state.currentListingIndex]);
-    const geolocation = currentListing.attributes.geolocation;
-
-    // Explicit type change to object literal for Google OverlayViews (geolocation is SDK type)
-    const latLngLiteral = { lat: geolocation.lat, lng: geolocation.lng };
     const hasCarousel = listings.length > 1;
     const pagination = hasCarousel ? (
       <div className={classNames(css.paginationInfo, css.borderRadiusInheritBottom)}>
@@ -155,25 +129,18 @@ class SearchMapInfoCard extends Component {
     const caretClass = classNames(css.caret, { [css.caretWithCarousel]: hasCarousel });
 
     return (
-      <CustomOverlayView
-        position={latLngLiteral}
-        mapPaneName={OverlayView.FLOAT_PANE}
-        getPixelPositionOffset={getPixelPositionOffset}
-        styles={{ zIndex: 1 }}
-      >
-        <div className={classes}>
-          <div className={css.caretShadow} />
-          <ListingCard
-            clickHandler={onListingInfoCardClicked}
-            urlToListing={createURLToListing(currentListing)}
-            listing={currentListing}
-            intl={intl}
-            isInCarousel={hasCarousel}
-          />
-          {pagination}
-          <div className={caretClass} />
-        </div>
-      </CustomOverlayView>
+      <div className={classes}>
+        <div className={css.caretShadow} />
+        <ListingCard
+          clickHandler={onListingInfoCardClicked}
+          urlToListing={createURLToListing(currentListing)}
+          listing={currentListing}
+          intl={intl}
+          isInCarousel={hasCarousel}
+        />
+        {pagination}
+        <div className={caretClass} />
+      </div>
     );
   }
 }

--- a/src/components/SearchMapPriceLabel/SearchMapPriceLabel.js
+++ b/src/components/SearchMapPriceLabel/SearchMapPriceLabel.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { OverlayView } from 'react-google-maps';
-import { OVERLAY_VIEW } from 'react-google-maps/lib/constants';
 import { injectIntl, intlShape } from 'react-intl';
 import classNames from 'classnames';
 import { propTypes } from '../../util/types';
@@ -10,26 +8,6 @@ import { ensureListing } from '../../util/data';
 import config from '../../config';
 
 import css from './SearchMapPriceLabel.css';
-
-// FIX "TypeError: Cannot read property 'overlayMouseTarget' of null"
-// Override draw function to catch errors with map panes being undefined to prevent console errors
-// https://github.com/tomchentw/react-google-maps/issues/482
-class CustomOverlayView extends OverlayView {
-  draw() {
-    // https://developers.google.com/maps/documentation/javascript/3.exp/reference#MapPanes
-    const mapPanes = this.state[OVERLAY_VIEW].getPanes();
-    // Add conditional to ensure panes and container exist before drawing
-    if (mapPanes && this.containerElement) {
-      super.draw();
-    }
-  }
-}
-
-// Center label so that caret is pointing to correct pixel.
-// (vertical positioning: height + arrow) */
-const getPixelPositionOffset = (width, height) => {
-  return { x: -1 * (width / 2), y: -1 * (height + 3) };
-};
 
 class SearchMapPriceLabel extends Component {
   shouldComponentUpdate(nextProps) {
@@ -45,30 +23,22 @@ class SearchMapPriceLabel extends Component {
   render() {
     const { className, rootClassName, intl, listing, onListingClicked, isActive } = this.props;
     const currentListing = ensureListing(listing);
-    const { geolocation, price } = currentListing.attributes;
+    const { price } = currentListing.attributes;
 
     // Create formatted price if currency is known or alternatively show just the unknown currency.
     const formattedPrice =
       price && price.currency === config.currency ? formatMoney(intl, price) : price.currency;
 
-    // Explicit type change to object literal for Google OverlayViews (geolocation is SDK type)
-    const latLngLiteral = { lat: geolocation.lat, lng: geolocation.lng };
     const classes = classNames(rootClassName || css.root, className);
     const priceLabelClasses = classNames(css.priceLabel, { [css.priceLabelActive]: isActive });
     const caretClasses = classNames(css.caret, { [css.caretActive]: isActive });
 
     return (
-      <CustomOverlayView
-        position={latLngLiteral}
-        mapPaneName={OverlayView.OVERLAY_MOUSE_TARGET}
-        getPixelPositionOffset={getPixelPositionOffset}
-      >
-        <button className={classes} onClick={() => onListingClicked(currentListing)}>
-          <div className={css.caretShadow} />
-          <div className={priceLabelClasses}>{formattedPrice}</div>
-          <div className={caretClasses} />
-        </button>
-      </CustomOverlayView>
+      <button className={classes} onClick={() => onListingClicked(currentListing)}>
+        <div className={css.caretShadow} />
+        <div className={priceLabelClasses}>{formattedPrice}</div>
+        <div className={caretClasses} />
+      </button>
     );
   }
 }

--- a/src/containers/SearchPage/SearchPage.js
+++ b/src/containers/SearchPage/SearchPage.js
@@ -10,12 +10,7 @@ import unionWith from 'lodash/unionWith';
 import classNames from 'classnames';
 import config from '../../config';
 import routeConfiguration from '../../routeConfiguration';
-import {
-  googleLatLngToSDKLatLng,
-  googleBoundsToSDKBounds,
-  sdkBoundsToFixedCoordinates,
-  hasSameSDKBounds,
-} from '../../util/googleMaps';
+import { sdkBoundsToFixedCoordinates, hasSameSDKBounds } from '../../util/googleMaps';
 import { createResourceLocatorString } from '../../util/routes';
 import { parse, stringify } from '../../util/urlHelpers';
 import { propTypes } from '../../util/types';
@@ -96,7 +91,7 @@ export class SearchPageComponent extends Component {
 
   // We are using Google Maps idle event instead of bounds_changed, since it will not be fired
   // too often (in the middle of map's pan or zoom activity)
-  onIdle(googleMap) {
+  onIdle(map) {
     const { history, location } = this.props;
 
     // parse query parameters, including a custom attribute named category
@@ -105,11 +100,9 @@ export class SearchPageComponent extends Component {
       latlngBounds: ['bounds'],
     });
 
-    const viewportGMapBounds = googleMap.getBounds();
-    const viewportBounds = sdkBoundsToFixedCoordinates(
-      googleBoundsToSDKBounds(viewportGMapBounds),
-      BOUNDS_FIXED_PRECISION
-    );
+    const viewportMapBounds = SearchMap.getMapBounds(map);
+    const viewportMapCenter = SearchMap.getMapCenter(map);
+    const viewportBounds = sdkBoundsToFixedCoordinates(viewportMapBounds, BOUNDS_FIXED_PRECISION);
 
     // ViewportBounds from (previous) rendering differ from viewportBounds currently set to map
     // I.e. user has changed the map somehow: moved, panned, zoomed, resized
@@ -120,9 +113,7 @@ export class SearchPageComponent extends Component {
     // or original location search is rendered once,
     // we start to react to 'bounds_changed' event by generating new searches
     if (viewportBoundsChanged && !this.modalOpenedBoundsChange) {
-      const originMaybe = config.sortSearchByDistance
-        ? { origin: googleLatLngToSDKLatLng(viewportGMapBounds.getCenter()) }
-        : {};
+      const originMaybe = config.sortSearchByDistance ? { origin: viewportMapCenter } : {};
       const searchParams = {
         address,
         ...originMaybe,

--- a/src/util/googleMaps.js
+++ b/src/util/googleMaps.js
@@ -90,33 +90,6 @@ export const getPlacePredictions = (search, sessionToken) =>
   });
 
 /**
- * Convert Google formatted LatLng object to Sharetribe SDK's LatLng coordinate format
- *
- * @param {LatLng} googleLatLng - Google Maps LatLng
- *
- * @return {SDKLatLng} - Converted latLng coordinate
- */
-export const googleLatLngToSDKLatLng = googleLatLng => {
-  return new SDKLatLng(googleLatLng.lat(), googleLatLng.lng());
-};
-
-/**
- * Convert Google formatted bounds object to Sharetribe SDK's bounds format
- *
- * @param {LatLngBounds} googleBounds - Google Maps LatLngBounds
- *
- * @return {SDKLatLngBounds} - Converted bounds
- */
-export const googleBoundsToSDKBounds = googleBounds => {
-  if (!googleBounds) {
-    return null;
-  }
-  const ne = googleBounds.getNorthEast();
-  const sw = googleBounds.getSouthWest();
-  return new SDKLatLngBounds(new SDKLatLng(ne.lat(), ne.lng()), new SDKLatLng(sw.lat(), sw.lng()));
-};
-
-/**
  * Cut some precision from bounds coordinates to tackle subtle map movements
  * when map is moved manually
  *


### PR DESCRIPTION
- [x] Refactor Google Maps integration to its own sub component on SearchMap
- [x] Refactor SearchMapPriceLabel (remove Google specific details)
- [x] Refactor SearchMapGroupLabel (remove Google specific details)
- [x] Refactor SearchMapInfoCard (remove Google specific details)
- [x] Create SearchMapWithMapbox component
- [x] Search by moving the map
- [x] Add Mapbox CSP rules
- [x] Add map controls
- [x] Figure out antimeridian (180 degree meridian) usage. ([Suggested way of adding degrees](https://github.com/mapbox/mapbox-gl-js/issues/2415#issuecomment-341835602) will need counter effect when speaking with Flex API (it gives 500 error)).
- [ ] Test on every device
- [ ] Try to figure out usage if possible (how many map views this generates?)

**NOTE: we'll merge this to init-mapbox branch / PR and then we test and fix found bugs on top of that branch.**
