### PR TITLE
Default location suggestions for LocationAutocompleteInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ way to update this template, but currently, we follow a pattern:
 ---
 ## Upcoming version 2018-08-XX
 
+* [change] Add support for default locations in the
+  LocationAutocompleteInput component. Common searches can be
+  configured to show when the input has focus. This reduces typing and
+  Google Places geolocation API usage. The defaults can be configured
+  in `src/components/LocationAutocompleteInput/GeocoderGoogleMaps.js`.
+  [#894](https://github.com/sharetribe/flex-template-web/pull/894)
 * [change] Removed the `country` parameter from the search page as it
   was not used anywhere.
   [#893](https://github.com/sharetribe/flex-template-web/pull/893)

--- a/docs/google-maps.md
+++ b/docs/google-maps.md
@@ -25,3 +25,14 @@ local development, you can add the variable in the Gitignored `.env` file in the
 ```
 REACT_APP_GOOGLE_MAPS_API_KEY=my-key-here
 ```
+
+## Setup common locations to reduce typing
+
+The location autocomplete input in the landing page and the topbar can
+be configured to have specific locations shown by default when the
+user focuses on the input and hasn't yet typed in any searches. This
+reduces the typing required for common searches, and also reduces the
+need to use the Google Places geolocation API that much.
+
+The default locations can be configured in
+[src/components/LocationAutocompleteInput/GeocoderGoogleMaps.js](../src/components/LocationAutocompleteInput/GeocoderGoogleMaps.js).

--- a/src/components/LocationAutocompleteInput/GeocoderGoogleMaps.js
+++ b/src/components/LocationAutocompleteInput/GeocoderGoogleMaps.js
@@ -45,6 +45,13 @@ class GeocoderGoogleMaps {
   }
 
   /**
+   * Get the ID of the given prediction.
+   */
+  getPredictionId(prediction) {
+    return prediction.place_id;
+  }
+
+  /**
    * Get the address text of the given prediction.
    */
   getPredictionAddress(prediction) {

--- a/src/components/LocationAutocompleteInput/GeocoderGoogleMaps.js
+++ b/src/components/LocationAutocompleteInput/GeocoderGoogleMaps.js
@@ -3,6 +3,30 @@ import { getPlacePredictions, getPlaceDetails } from '../../util/googleMaps';
 
 import css from './LocationAutocompleteInput.css';
 
+// A list of default predictions that can be shown when the user
+// focuses on the autocomplete input without typing a search. This can
+// be used to reduce typing and Geocoding API calls for common
+// searches.
+//
+// Example:
+//
+// [
+//   {
+//     place_id: 'Place ID from Google Maps Places API',
+//     description: 'Place name to show in the autocomplete dropdown',
+//   },
+// ]
+//
+// To know which values to set as defaults, log a real prediction
+// object from the Places API call and copy the Place ID from the
+// response.
+export const defaultPredictions = [
+  // {
+  //   place_id: 'ChIJkQYhlscLkkYRY_fiO4S9Ts0',
+  //   description: 'Helsinki, Finland',
+  // },
+];
+
 // When displaying data from the Google Maps Places API, and
 // attribution is required next to the results.
 // See: https://developers.google.com/places/web-service/policies#powered

--- a/src/components/LocationAutocompleteInput/GeocoderMapbox.js
+++ b/src/components/LocationAutocompleteInput/GeocoderMapbox.js
@@ -26,6 +26,34 @@ const placeBounds = prediction => {
   return null;
 };
 
+// A list of default predictions that can be shown when the user
+// focuses on the autocomplete input without typing a search. This can
+// be used to reduce typing and Geocoding API calls for common
+// searches.
+//
+// Example:
+//
+// [
+//   {
+//     id: 'any unique id',
+//     place_name: 'Place name to show in the autocomplete dropdown',
+//     center: [longitude, latitude],
+//     bbox: [minX, minY, maxX, maxY],
+//   },
+// ]
+//
+// To know which values to set as defaults, log a real prediction
+// object from the Geocoding API call and check the values from the
+// response.
+export const defaultPredictions = [
+  // {
+  //   id: 'default-helsinki',
+  //   place_name: 'Helsinki, Finland',
+  //   center: [24.94861, 60.17333],
+  //   bbox: [24.82617, 60.075361, 25.313112, 60.297839],
+  // },
+];
+
 export const GeocoderAttribution = () => null;
 
 /**

--- a/src/components/LocationAutocompleteInput/GeocoderMapbox.js
+++ b/src/components/LocationAutocompleteInput/GeocoderMapbox.js
@@ -3,6 +3,8 @@ import config from '../../config';
 
 const { LatLng: SDKLatLng, LatLngBounds: SDKLatLngBounds } = sdkTypes;
 
+const placeId = prediction => prediction.id;
+
 const placeAddress = prediction => prediction.place_name;
 
 const placeOrigin = prediction => {
@@ -64,6 +66,13 @@ class GeocoderMapbox {
           predictions: response.body.features,
         };
       });
+  }
+
+  /**
+   * Get the ID of the given prediction.
+   */
+  getPredictionId(prediction) {
+    return placeId(prediction);
   }
 
   /**

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -69,7 +69,7 @@ const LocationPredictionsList = props => {
     return (
       <li
         className={isHighlighted ? css.highlighted : null}
-        key={prediction.id}
+        key={geocoder.getPredictionId(prediction)}
         onTouchStart={e => onSelectStart(getTouchCoordinates(e.nativeEvent))}
         onMouseDown={() => onSelectStart()}
         onTouchMove={e => onSelectMove(getTouchCoordinates(e.nativeEvent))}

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -73,8 +73,8 @@ const LocationPredictionsList = props => {
         onTouchStart={e => onSelectStart(getTouchCoordinates(e.nativeEvent))}
         onMouseDown={() => onSelectStart()}
         onTouchMove={e => onSelectMove(getTouchCoordinates(e.nativeEvent))}
-        onTouchEnd={() => onSelectEnd(index)}
-        onMouseUp={() => onSelectEnd(index)}
+        onTouchEnd={() => onSelectEnd(prediction)}
+        onMouseUp={() => onSelectEnd(prediction)}
       >
         {geocoder.getPredictionAddress(prediction)}
       </li>
@@ -149,7 +149,7 @@ class LocationAutocompleteInputImpl extends Component {
     this.geocoder = new Geocoder();
 
     this.changeHighlight = this.changeHighlight.bind(this);
-    this.selectItem = this.selectItem.bind(this);
+    this.selectPrediction = this.selectPrediction.bind(this);
     this.selectItemIfNoneSelected = this.selectItemIfNoneSelected.bind(this);
     this.onKeyDown = this.onKeyDown.bind(this);
     this.onChange = this.onChange.bind(this);
@@ -244,16 +244,7 @@ class LocationAutocompleteInputImpl extends Component {
 
   // Select the prediction in the given item. This will fetch/read the
   // place details and set it as the selected place.
-  selectItem(index) {
-    if (index < 0) {
-      return;
-    }
-    const { predictions } = currentValue(this.props);
-    if (index >= predictions.length) {
-      return;
-    }
-    const prediction = predictions[index];
-
+  selectPrediction(prediction) {
     this.props.input.onChange({
       ...this.props.input,
       selectedPlace: null,
@@ -278,10 +269,13 @@ class LocationAutocompleteInputImpl extends Component {
       });
   }
   selectItemIfNoneSelected() {
-    const { search, selectedPlace } = currentValue(this.props);
+    const { search, selectedPlace, predictions } = currentValue(this.props);
     if (search && !selectedPlace) {
       const index = this.state.highlightedIndex !== -1 ? this.state.highlightedIndex : 0;
-      this.selectItem(index);
+
+      if (index >= 0 && index < predictions.length) {
+        this.selectPrediction(predictions[index]);
+      }
     }
   }
   predict(search) {
@@ -350,7 +344,7 @@ class LocationAutocompleteInputImpl extends Component {
     });
   }
 
-  handlePredictionsSelectEnd(index) {
+  handlePredictionsSelectEnd(prediction) {
     let selectAndFinalize = false;
     this.setState(
       prevState => {
@@ -361,7 +355,7 @@ class LocationAutocompleteInputImpl extends Component {
       },
       () => {
         if (selectAndFinalize) {
-          this.selectItem(index);
+          this.selectPrediction(prediction);
           this.finalizeSelection();
         }
       }


### PR DESCRIPTION
This PR adds support for default location predictions in the `LocationAutocompleteInput`. This will reduce the amount of typing and Geocoding API calls for common searches.

Default predictions can be configured in the Geocoder implementation as the exact format depends on the Geocoding API that is in use.