### PR TITLE
Unify default search data and avoid place details API call

### DIFF
--- a/src/components/LocationAutocompleteInput/GeocoderGoogleMaps.js
+++ b/src/components/LocationAutocompleteInput/GeocoderGoogleMaps.js
@@ -1,7 +1,10 @@
 import React from 'react';
+// import { types as sdkTypes } from '../../util/sdkLoader';
 import { getPlacePredictions, getPlaceDetails, locationBounds } from '../../util/googleMaps';
 import { userLocation } from '../../util/maps';
 import css from './LocationAutocompleteInput.css';
+
+// const { LatLng: SDKLatLng, LatLngBounds: SDKLatLngBounds } = sdkTypes;
 
 export const CURRENT_LOCATION_ID = 'current-location';
 const CURRENT_LOCATION_BOUNDS_DISTANCE = 1000; // meters
@@ -10,29 +13,24 @@ const CURRENT_LOCATION_BOUNDS_DISTANCE = 1000; // meters
 // focuses on the autocomplete input without typing a search. This can
 // be used to reduce typing and Geocoding API calls for common
 // searches.
-//
-// Example:
-//
-// [
-//   {
-//     place_id: 'Place ID from Google Maps Places API',
-//     description: 'Place name to show in the autocomplete dropdown',
-//   },
-// ]
-//
-// To know which values to set as defaults, log a real prediction
-// object from the Places API call and copy the Place ID from the
-// response.
 export const defaultPredictions = [
-  // // Current user location
+  // Examples:
+  // Current user location from the browser geolocation API
   // {
-  //   place_id: CURRENT_LOCATION_ID,
-  //   // LocationAutocompleteInputImpl adds the text from the translations
-  //   description: '',
+  //   id: CURRENT_LOCATION_ID,
+  //   predictionPlace: {},
   // },
+  // Helsinki
   // {
-  //   place_id: 'ChIJkQYhlscLkkYRY_fiO4S9Ts0',
-  //   description: 'Helsinki, Finland',
+  //   id: 'default-helsinki',
+  //   predictionPlace: {
+  //     address: 'Helsinki, Finland',
+  //     origin: new SDKLatLng(60.16985, 24.93837),
+  //     bounds: new SDKLatLngBounds(
+  //       new SDKLatLng(60.29783, 25.25448),
+  //       new SDKLatLng(59.92248, 24.78287)
+  //     ),
+  //   },
   // },
 ];
 
@@ -81,6 +79,11 @@ class GeocoderGoogleMaps {
    * Get the ID of the given prediction.
    */
   getPredictionId(prediction) {
+    if (prediction.predictionPlace) {
+      // default prediction defined above
+      return prediction.id;
+    }
+    // prediction from Google Maps Places API
     return prediction.place_id;
   }
 
@@ -88,6 +91,11 @@ class GeocoderGoogleMaps {
    * Get the address text of the given prediction.
    */
   getPredictionAddress(prediction) {
+    if (prediction.predictionPlace) {
+      // default prediction defined above
+      return prediction.predictionPlace.address;
+    }
+    // prediction from Google Maps Places API
     return prediction.description;
   }
 
@@ -107,6 +115,10 @@ class GeocoderGoogleMaps {
           bounds: locationBounds(latlng, CURRENT_LOCATION_BOUNDS_DISTANCE),
         };
       });
+    }
+
+    if (prediction.predictionPlace) {
+      return Promise.resolve(prediction.predictionPlace);
     }
 
     return getPlaceDetails(prediction.place_id, this.getSessionToken()).then(place => {


### PR DESCRIPTION
This PR unifies the Google Maps and Mapbox default search data structures and removes the extra Google Maps Places API call for the default search place details.

This should reduce the cost of using Google Maps and prepares the config to live somewhere else if we wish to do that at some point.