### PR TITLE
Disable default predictions in listing editing wizard

### DIFF
--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -181,9 +181,11 @@ class LocationAutocompleteInputImpl extends Component {
 
   currentPredictions() {
     const { search, predictions: fetchedPredictions } = currentValue(this.props);
+    const { useDefaultPredictions } = this.props;
     const hasFetchedPredictions = fetchedPredictions && fetchedPredictions.length > 0;
+    const showDefaultPredictions = !search && !hasFetchedPredictions && useDefaultPredictions;
 
-    return !search && !hasFetchedPredictions ? defaultPredictions : fetchedPredictions;
+    return showDefaultPredictions ? defaultPredictions : fetchedPredictions;
   }
 
   // Interpret input key event
@@ -487,6 +489,7 @@ LocationAutocompleteInputImpl.defaultProps = {
   predictionsAttributionClassName: null,
   validClassName: null,
   placeholder: '',
+  useDefaultPredictions: true,
   meta: null,
   inputRef: null,
 };
@@ -502,6 +505,7 @@ LocationAutocompleteInputImpl.propTypes = {
   predictionsAttributionClassName: string,
   validClassName: string,
   placeholder: string,
+  useDefaultPredictions: bool,
   input: shape({
     name: string.isRequired,
     value: oneOfType([

--- a/src/forms/EditListingLocationForm/EditListingLocationForm.js
+++ b/src/forms/EditListingLocationForm/EditListingLocationForm.js
@@ -72,6 +72,7 @@ export const EditListingLocationFormComponent = props => (
             name="location"
             label={titleRequiredMessage}
             placeholder={addressPlaceholderMessage}
+            useDefaultPredictions={false}
             format={null}
             valueFromForm={values.location}
             validate={composeValidators(


### PR DESCRIPTION
Adds a prop to `LocationAutocompleteInputImpl` that can be passed to `LocationAutocompleteInput` to disable default predictions in a location input.