### PR TITLE
Fix search after navigation

### DIFF
--- a/src/components/SearchMap/SearchMapWithMapbox.js
+++ b/src/components/SearchMap/SearchMapWithMapbox.js
@@ -241,10 +241,10 @@ class SearchMapWithMapbox extends Component {
   componentDidUpdate(prevProps) {
     if (!this.map) {
       this.initializeMap();
-
-      /* Notify parent component that Mapbox map is loaded */
-      this.props.onMapLoad(this.map);
     }
+
+    /* Notify parent component that Mapbox map is loaded */
+    this.props.onMapLoad(this.map);
   }
 
   onMount(element) {


### PR DESCRIPTION
Mapbox does not update when performing a search with the following steps:
 - Search for "Helsinki"
 - Navigate away from search page, to for example a listing page
 - Search for "New York" in top bar