### PR TITLE
Referrer policy updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ way to update this template, but currently, we follow a pattern:
 ---
 
 ## Upcoming version 2018-10-XX
-
+* [add] Add referrer policy due tokens in URL on PasswordResetPage and EmailVerificationPage.
+  [#940](https://github.com/sharetribe/flex-template-web/pull/940)
 * [add] Added initial documentation about our Redux setup.
   [#939](https://github.com/sharetribe/flex-template-web/pull/939)
 * [add] Added a small comment to documentation about the current state of code-splitting.

--- a/src/containers/EmailVerificationPage/EmailVerificationPage.js
+++ b/src/containers/EmailVerificationPage/EmailVerificationPage.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Helmet from 'react-helmet';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -61,6 +62,9 @@ export const EmailVerificationPageComponent = props => {
 
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
+      <Helmet>
+        <meta name="referrer" content="origin" />
+      </Helmet>
       <LayoutSingleColumn>
         <LayoutWrapperTopbar>
           <TopbarContainer />

--- a/src/containers/PasswordResetPage/PasswordResetPage.js
+++ b/src/containers/PasswordResetPage/PasswordResetPage.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import Helmet from 'react-helmet';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
@@ -122,6 +123,10 @@ export class PasswordResetPageComponent extends Component {
 
     return (
       <Page title={title} scrollingDisabled={scrollingDisabled}>
+        <Helmet>
+          <meta name="referrer" content="origin" />
+        </Helmet>
+
         <LayoutSingleColumn>
           <LayoutWrapperTopbar>
             <TopbarContainer />


### PR DESCRIPTION
This update is to ensure that page with URLs that contain tokens from API, doesn't leak that information to external links. (Including links in `<head>` section, CSS files etc.)

> NOTE: remember to use `<ExternalLink>` component always when dealing with external links.
> [ExternalLink](https://github.com/sharetribe/flex-template-web/blob/master/src/components/ExternalLink/ExternalLink.js)