### PR TITLE
Translations management CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ way to update this template, but currently, we follow a pattern:
   [#960](https://github.com/sharetribe/flex-template-web/pull/960)
 * [fix] Remove unused translation keys and update PasswordChangePage title
   [#959](https://github.com/sharetribe/flex-template-web/pull/959)
+* [fix] Add translations CLI tool
+  [#955](https://github.com/sharetribe/flex-template-web/pull/955)
 
 ## [v2.3.2] 2018-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,13 @@ way to update this template, but currently, we follow a pattern:
   [#960](https://github.com/sharetribe/flex-template-web/pull/960)
 * [fix] Remove unused translation keys and update PasswordChangePage title
   [#959](https://github.com/sharetribe/flex-template-web/pull/959)
-* [fix] Add translations CLI tool
-  [#955](https://github.com/sharetribe/flex-template-web/pull/955)
+* [fix] Add translations CLI tool [#955](https://github.com/sharetribe/flex-template-web/pull/955)
 
 ## [v2.3.2] 2018-11-20
 
 * [fix] Take 2: don't set currentUserHasListings if fetched listing is in draft state.
   [#956](https://github.com/sharetribe/flex-template-web/pull/956)
-* [fix] PriceFilter styles
-  [#954](https://github.com/sharetribe/flex-template-web/pull/954)
+* [fix] PriceFilter styles [#954](https://github.com/sharetribe/flex-template-web/pull/954)
 
 [v2.3.2]: https://github.com/sharetribe/flex-template-web/compare/v2.3.1...v2.3.2
 
@@ -324,4 +322,3 @@ way to update this template, but currently, we follow a pattern:
 ## v0.2.0
 
 * Starting a change log for Flex Template for Web.
-

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -165,13 +165,22 @@ import messages from '../translations/es.json';
 ## Managing translations
 
 In case you have added a new language translation file and are pulling translation updates to
-`en.json` from the upstream repo there is a command line tool to help keeping the translation files in
-sync. Running the following command in the project root
+`en.json` from the upstream repo there is a command line tool to help keeping the translation files
+in sync. Running the following command in the project root
 
 ```
 node translations.js
-
 ```
-will start a command line application that can be used to match a translation file agains the
-English translations. Just modify the `translations.js` file and add you language to the
-`TARGET_LANGS` array and it will be available in the tool.
+
+will start a command line application:
+
+![Translations CLI](./assets/translations/translations_cli.gif)
+
+The command line application can be used to match a translation file against the English
+translations. If your new translations file follows the `<LANG CODE>.json` naming, the CLI will pick
+it up automatically. In order to improve readability, you can add the language name to the
+`TARGET_LANG_NAMES` map in `translations.js` if it is not yet in there and the CLI will use the
+correct name for your language instead of the language code when prompting about translations.
+
+In case you wish to use something else than English as the source language, modify the `SOURCE_LANG`
+object in `translations.js` to match your needs.

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -161,3 +161,17 @@ in tests. To change the translation file used in tests change the `messages` var
 ```js
 import messages from '../translations/es.json';
 ```
+
+## Managing translations
+
+In case you have added a new language translation file and are pulling translation updates to
+`en.json` from the upstream repo there is a command line tool to help keeping the translation files in
+sync. Running the following command in the project root
+
+```
+node translations.js
+
+```
+will start a command line application that can be used to match a translation file agains the
+English translations. Just modify the `translations.js` file and add you language to the
+`TARGET_LANGS` array and it will be available in the tool.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.3",
+    "inquirer": "^6.2.0",
     "nodemon": "^1.17.2",
     "nsp": "^3.2.1",
     "nsp-preprocessor-yarn": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "url": "^0.11.0"
   },
   "devDependencies": {
+    "chalk": "^2.4.1",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",
     "enzyme-to-json": "^3.3.3",

--- a/translations
+++ b/translations
@@ -44,7 +44,6 @@ const run = () => {
       targetKeys = Object.keys(target);
 
       const diff = difference(sourceKeys, targetKeys);
-      console.log(`target: ${target}`);
 
       if (diff.length > 0) {
         return selectKey(targetLang, diff, source, target);

--- a/translations
+++ b/translations
@@ -56,6 +56,7 @@ const targetLangChoices = () => {
   const filenames = fs.readdirSync(folder);
 
   const choices = filenames
+    .filter(name => name.endsWith('.json'))
     .map(name => name.split('.')[0])
     .filter(code => code !== SOURCE_LANG.value)
     .map(code => {

--- a/translations
+++ b/translations
@@ -33,6 +33,7 @@ const run = () => {
   let sourceKeys;
   let targetKeys;
   let key;
+  let translation;
 
   selectLanguage()
     .then(answers => {
@@ -62,7 +63,19 @@ const run = () => {
       }
     })
     .then(answers => {
-      target[key] = answers.value;
+      translation = answers.value;
+      return confirmTranslation(targetLang, key, translation);
+    })
+    .then(answers => {
+      // a bool value if translation addition is confirmed
+      const confirmation = answers.value;
+
+      if (!confirmation) {
+        console.log('Discarding new translation');
+        throw new BreakSignal();
+      }
+
+      target[key] = translation;
 
       const sorted = sort(target);
       const data = JSON.stringify(sorted, null, 2);
@@ -175,6 +188,29 @@ const addTranslation = (targetLang, key, source) => {
       )} for the key ${chalk.blueBright(key)}. The current ${
         SOURCE_LANG.name
       } translation is ${chalk.green(source[key])}`,
+    },
+  ]);
+};
+
+/**
+ * Prompt for a confirming a new translation with 'y' or 'N'.
+ *
+ * @param {String} targetLang The language that is being translated
+ * @param {String} key Key for the new translation
+ * @param {Object} source Source language translations
+ *
+ * @return a Promise with the answers hash containing a boolean value field
+ */
+const confirmTranslation = (targetLang, key, translation) => {
+  return inquirer.prompt([
+    {
+      type: 'input',
+      name: 'value',
+      message: `Do you want to add the ${targetLangName(targetLang)} translation ${chalk.green(
+        translation
+      )} for the key ${chalk.blueBright(key)}? (y/N)`,
+      filter: value => (value === 'y' ? true : value === 'N' ? false : value),
+      validate: value => value === true || value === false,
     },
   ]);
 };

--- a/translations
+++ b/translations
@@ -151,13 +151,10 @@ const run = () => {
       const sorted = sort(target);
       const data = JSON.stringify(sorted, null, 2);
 
-      fs.writeFile(filePath(targetLang), data, err => {
-        if (err) {
-          throw err;
-        }
-        console.log(chalk.bold('The translation file is updated'));
-        run();
-      });
+      return updateTranslationsFile(data, targetLang);
+    })
+    .then(() => {
+      run();
     })
     .catch(err => {
       if (err instanceof BreakSignal) {
@@ -255,6 +252,26 @@ const confirmTranslation = (targetLang, key, translation) => {
       validate: value => value === true || value === false,
     },
   ]);
+};
+
+/**
+ * Update translations file.
+ *
+ * @param {String} data String data to be written to file
+ * @param {String} targetLang Language code of the translation file
+ *
+ * @return a Promise that resolves when file is written
+ */
+const updateTranslationsFile = (data, targetLang) => {
+  return new Promise((resolve, reject) => {
+    fs.writeFile(filePath(targetLang), data, err => {
+      if (err) {
+        reject(err);
+      }
+      console.log(chalk.bold('The translation file is updated'));
+      resolve();
+    });
+  });
 };
 
 run();

--- a/translations
+++ b/translations
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * A translations too that can be used to keep a translation file(s)
  * up to date with one source language file.

--- a/translations
+++ b/translations
@@ -25,6 +25,46 @@ const TARGET_LANGS = [
 
 class BreakSignal {}
 
+/**
+ * Resolves translation file path for a lang code: en, es, de, etc.
+ */
+const filePath = lang => `${PATH}${lang}.json`;
+
+/**
+ * Resolves name of a target language based on
+ * a language code: en, es, de, etc.
+ */
+const targetLangName = lang => {
+  const targetLang = TARGET_LANGS.filter(l => l.value === lang)[0];
+  return targetLang.name;
+};
+
+/**
+ * Sorts an object by key.
+ *
+ * Relies on an object keeping the order in which entries are added for string keys.
+ * See: http://exploringjs.com/es6/ch_oop-besides-classes.html#_traversal-order-of-properties
+ */
+const sort = obj => {
+  const sorted = {};
+  Object.keys(obj)
+    .sort()
+    .forEach(key => (sorted[key] = obj[key]));
+
+  return sorted;
+};
+
+/**
+ * Reads a file with JSON content and returns
+ * a JS object.
+ *
+ * @param filepath
+ */
+const readFileToJSON = filepath => {
+  const rawdata = fs.readFileSync(filepath);
+  return JSON.parse(rawdata);
+};
+
 const run = () => {
   let sourceLang;
   let targetLang;
@@ -39,8 +79,8 @@ const run = () => {
     .then(answers => {
       sourceLang = SOURCE_LANG.value;
       targetLang = answers.lang;
-      source = require(filePath(sourceLang));
-      target = require(filePath(targetLang));
+      source = readFileToJSON(filePath(sourceLang));
+      target = readFileToJSON(filePath(targetLang));
       sourceKeys = Object.keys(source);
       targetKeys = Object.keys(target);
 
@@ -96,35 +136,6 @@ const run = () => {
         console.log(chalk.red(`An error occurred due to: ${err.message}`));
       }
     });
-};
-
-/**
- * Resolves translation file path for a lang code: en, es, de, etc.
- */
-const filePath = lang => `${PATH}${lang}.json`;
-
-/**
- * Resolves name of a target language based on
- * a language code: en, es, de, etc.
- */
-const targetLangName = lang => {
-  const targetLang = TARGET_LANGS.filter(l => l.value === lang)[0];
-  return targetLang.name;
-};
-
-/**
- * Sorts an object by key.
- *
- * Relies on an object keeping the order in which entries are added for string keys.
- * See: http://exploringjs.com/es6/ch_oop-besides-classes.html#_traversal-order-of-properties
- */
-const sort = obj => {
-  const sorted = {};
-  Object.keys(obj)
-    .sort()
-    .forEach(key => (sorted[key] = obj[key]));
-
-  return sorted;
 };
 
 /**

--- a/translations
+++ b/translations
@@ -4,7 +4,9 @@
  * A translations too that can be used to keep a translation file(s)
  * up to date with one source language file.
  *
- * To track new languages add a desired language to the TARGET_LANGS array.
+ * Possible target languages are resolved from the translation files
+ * available. When adding a new tranlation file, the language name can
+ * be added to the TARGET_LANG_NAMES map for clearer prompt messages.
  * By default the translations are matched agains English translations
  * but that can be changed by modifying the SOURCE_LANG.
  */
@@ -17,11 +19,11 @@ const chalk = require('chalk');
 const PATH = './src/translations/';
 
 const SOURCE_LANG = { name: 'English', value: 'en' };
-const TARGET_LANGS = [
-  { name: 'Spanish', value: 'es' },
-  { name: 'German', value: 'de' },
-  { name: 'French', value: 'fr' },
-];
+const TARGET_LANG_NAMES = {
+  es: 'Spanish',
+  de: 'German',
+  fr: 'French',
+};
 
 class BreakSignal {}
 
@@ -33,10 +35,37 @@ const filePath = lang => `${PATH}${lang}.json`;
 /**
  * Resolves name of a target language based on
  * a language code: en, es, de, etc.
+ *
+ * If a lang name is not found, language code is returned.
  */
-const targetLangName = lang => {
-  const targetLang = TARGET_LANGS.filter(l => l.value === lang)[0];
-  return targetLang.name;
+const targetLangName = code => {
+  const name = TARGET_LANG_NAMES[code];
+
+  return name || code;
+};
+
+/**
+ * Resolve a list of target language choices by finding all possible
+ * translation files and filtering out the SOURCE_LANG. Provides a list
+ * of objects that can be passed to inquirer.
+ *
+ * Relies on translation file naming: <lang code>.json
+ */
+const targetLangChoices = () => {
+  const folder = './src/translations/';
+  const filenames = fs.readdirSync(folder);
+
+  const choices = filenames
+    .map(name => name.split('.')[0])
+    .filter(code => code !== SOURCE_LANG.value)
+    .map(code => {
+      return {
+        name: targetLangName(code),
+        value: code,
+      };
+    });
+
+  return choices;
 };
 
 /**
@@ -75,7 +104,9 @@ const run = () => {
   let key;
   let translation;
 
-  selectLanguage()
+  const choices = targetLangChoices();
+
+  selectLanguage(choices)
     .then(answers => {
       sourceLang = SOURCE_LANG.value;
       targetLang = answers.lang;
@@ -144,13 +175,13 @@ const run = () => {
  *
  * @return a Promise
  */
-const selectLanguage = () => {
+const selectLanguage = choices => {
   return inquirer.prompt([
     {
       type: 'list',
       name: 'lang',
       message: 'Which language would you like to inspect? (Or hit Ctrl+C to quit)',
-      choices: TARGET_LANGS,
+      choices: choices,
     },
   ]);
 };

--- a/translations.js
+++ b/translations.js
@@ -16,7 +16,7 @@ const chalk = require('chalk');
 
 const PATH = './src/translations/';
 
-const SOURCE_LANG = { name: 'English', value: 'en' };
+const SOURCE_LANG = { name: 'English', code: 'en' };
 const TARGET_LANG_NAMES = {
   es: 'Spanish',
   de: 'German',
@@ -56,7 +56,7 @@ const targetLangChoices = () => {
   const choices = filenames
     .filter(name => name.endsWith('.json'))
     .map(name => name.split('.')[0])
-    .filter(code => code !== SOURCE_LANG.value)
+    .filter(code => code !== SOURCE_LANG.code)
     .map(code => {
       return {
         name: targetLangName(code),
@@ -107,7 +107,7 @@ const run = () => {
 
   selectLanguage(choices)
     .then(answers => {
-      sourceLang = SOURCE_LANG.value;
+      sourceLang = SOURCE_LANG.code;
       targetLang = answers.lang;
       source = readFileToJSON(filePath(sourceLang));
       target = readFileToJSON(filePath(targetLang));

--- a/translations.js
+++ b/translations.js
@@ -159,10 +159,10 @@ const translateLanguage = (targetLang, source, target, diff) => {
       return confirmTranslation(targetLang, key, translation);
     })
     .then(answers => {
-      // 'y' or 'N'
+      // y|Y|n|N
       const confirmation = answers.value;
 
-      if (confirmation === 'N') {
+      if (/n/i.test(confirmation)) {
         console.log('Discarding new translation');
         throw new BreakToRunWithTarget();
       }
@@ -271,8 +271,8 @@ const confirmTranslation = (targetLang, key, translation) => {
       name: 'value',
       message: `Do you want to add the ${targetLangName(targetLang)} translation ${chalk.green(
         translation
-      )} for the key ${chalk.blueBright(key)}? (y/N)`,
-      validate: value => value === 'y' || value === 'N',
+      )} for the key ${chalk.blueBright(key)}? (y/n)`,
+      validate: value => /y/i.test(value) || /n/i.test(value),
     },
   ]);
 };

--- a/translations.js
+++ b/translations.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * A translations too that can be used to keep a translation file(s)
  * up to date with one source language file.

--- a/translations.js
+++ b/translations.js
@@ -225,7 +225,7 @@ const addTranslation = (targetLang, key, source) => {
         targetLang
       )} for the key ${chalk.blueBright(key)}. The current ${
         SOURCE_LANG.name
-      } translation is ${chalk.green(source[key])}`,
+      } translation is ${chalk.green(source[key])} \n`,
     },
   ]);
 };

--- a/translations.js
+++ b/translations.js
@@ -1,0 +1,170 @@
+/**
+ * A translations too that can be used to keep a translation file(s)
+ * up to date with one source language file.
+ */
+const inquirer = require('inquirer');
+const difference = require('lodash/difference');
+const fs = require('fs');
+
+const PATH = './src/translations/';
+
+const SOURCE_LANG = { name: 'English', value: 'en' };
+const TARGET_LANGS = [
+  { name: 'Spanish', value: 'es' },
+  { name: 'German', value: 'de' },
+  { name: 'French', value: 'fr' },
+];
+
+class BreakSignal {}
+
+const run = () => {
+  let sourceLang;
+  let targetLang;
+  let source;
+  let target;
+  let sourceKeys;
+  let targetKeys;
+  let key;
+
+  selectLanguage()
+    .then(answers => {
+      sourceLang = SOURCE_LANG.value;
+      targetLang = answers.lang;
+      source = require(filePath(sourceLang));
+      target = require(filePath(targetLang));
+      sourceKeys = Object.keys(source);
+      targetKeys = Object.keys(target);
+
+      const diff = difference(sourceKeys, targetKeys);
+      console.log(`target: ${target}`);
+
+      if (diff.length > 0) {
+        return selectKey(targetLang, diff, source, target);
+      } else {
+        console.log(`No translations missing from the ${targetLangName(targetLang)} translations`);
+        throw new BreakSignal();
+      }
+    })
+    .then(answers => {
+      key = answers.key;
+      if (key === null) {
+        throw new BreakSignal();
+      }
+      if (key != null) {
+        return addTranslation(targetLang, key, source);
+      }
+    })
+    .then(answers => {
+      target[key] = answers.value;
+
+      const sorted = sort(target);
+      const data = JSON.stringify(sorted, null, 2);
+
+      fs.writeFile(filePath(targetLang), data, err => {
+        if (err) {
+          throw err;
+        }
+        console.log('The translation file is updated');
+        run();
+      });
+    })
+    .catch(err => {
+      if (err instanceof BreakSignal) {
+        // break out of Promise chain, start from start
+        run();
+      } else {
+        console.log(`An error occurred due to: ${err.message}`);
+      }
+    });
+};
+
+/**
+ * Resolves translation file path for a lang code: en, es, de, etc.
+ */
+const filePath = lang => `${PATH}${lang}.json`;
+
+/**
+ * Resolves name of a target language based on
+ * a language code: en, es, de, etc.
+ */
+const targetLangName = lang => {
+  const targetLang = TARGET_LANGS.filter(l => l.value === lang)[0];
+  return targetLang.name;
+};
+
+/**
+ * Sorts an object by key.
+ *
+ * Relies on an object keeping the order in which entries are added for string keys.
+ * See: http://exploringjs.com/es6/ch_oop-besides-classes.html#_traversal-order-of-properties
+ */
+const sort = obj => {
+  const sorted = {};
+  Object.keys(obj)
+    .sort()
+    .forEach(key => (sorted[key] = obj[key]));
+
+  return sorted;
+};
+
+/**
+ * Prompt for selecting the language of which
+ * translations are inspected.
+ *
+ * @return a Promise
+ */
+const selectLanguage = () => {
+  return inquirer.prompt([
+    {
+      type: 'list',
+      name: 'lang',
+      message: 'Which language would you like to inspect? (Or hit Ctrl+C to quit)',
+      choices: TARGET_LANGS,
+    },
+  ]);
+};
+
+/**
+ * Prompt for selecting a key that is missing from the target language translations.
+ *
+ * @param {String} targetLang The language that is being translated
+ * @param {Array} diff Keys missing frrom target language translations
+ *
+ * @return a Promise
+ */
+const selectKey = (targetLang, diff, source, target) => {
+  const choices = [{ name: 'I prefer not to', value: null }, ...diff];
+  return inquirer.prompt([
+    {
+      type: 'list',
+      name: 'key',
+      message: `The following translation keys are missing from the ${targetLangName(
+        targetLang
+      )} translations. Select a key to add a translation.`,
+      choices: choices,
+    },
+  ]);
+};
+
+/**
+ * Prompt for a new translation in target language.
+ *
+ * @param {String} targetLang The language that is being translated
+ * @param {String} key Key for the new translation
+ * @param {Object} source Source language translations
+ *
+ * @return a Promise
+ */
+const addTranslation = (targetLang, key, source) => {
+  return inquirer.prompt([
+    {
+      type: 'input',
+      name: 'value',
+      message: `Please provide a translation in ${targetLangName(
+        targetLang
+      )} for the key "${key}". The current ${SOURCE_LANG.name} translation is "${source[key]}"`,
+    },
+  ]);
+};
+
+run();

--- a/translations.js
+++ b/translations.js
@@ -144,7 +144,9 @@ const selectKey = (targetLang, diff, source, target) => {
     {
       type: 'list',
       name: 'key',
-      message: `The following translation keys (${diff.length}) are missing from the ${targetLangName(
+      message: `The following translation keys (${
+        diff.length
+      }) are missing from the ${targetLangName(
         targetLang
       )} translations. Select a key to add a translation.`,
       choices: choices,
@@ -169,7 +171,9 @@ const addTranslation = (targetLang, key, source) => {
       name: 'value',
       message: `Please provide a translation in ${targetLangName(
         targetLang
-      )} for the key ${chalk.blueBright(key)}. The current ${SOURCE_LANG.name} translation is ${chalk.green(source[key])}`,
+      )} for the key ${chalk.blueBright(key)}. The current ${
+        SOURCE_LANG.name
+      } translation is ${chalk.green(source[key])}`,
     },
   ]);
 };

--- a/translations.js
+++ b/translations.js
@@ -5,6 +5,7 @@
 const inquirer = require('inquirer');
 const difference = require('lodash/difference');
 const fs = require('fs');
+const chalk = require('chalk');
 
 const PATH = './src/translations/';
 
@@ -64,7 +65,7 @@ const run = () => {
         if (err) {
           throw err;
         }
-        console.log('The translation file is updated');
+        console.log(chalk.bold('The translation file is updated'));
         run();
       });
     })
@@ -73,7 +74,7 @@ const run = () => {
         // break out of Promise chain, start from start
         run();
       } else {
-        console.log(`An error occurred due to: ${err.message}`);
+        console.log(chalk.red(`An error occurred due to: ${err.message}`));
       }
     });
 };
@@ -162,7 +163,7 @@ const addTranslation = (targetLang, key, source) => {
       name: 'value',
       message: `Please provide a translation in ${targetLangName(
         targetLang
-      )} for the key "${key}". The current ${SOURCE_LANG.name} translation is "${source[key]}"`,
+      )} for the key ${chalk.blueBright(key)}. The current ${SOURCE_LANG.name} translation is ${chalk.green(source[key])}`,
     },
   ]);
 };

--- a/translations.js
+++ b/translations.js
@@ -137,10 +137,10 @@ const run = () => {
       return confirmTranslation(targetLang, key, translation);
     })
     .then(answers => {
-      // a bool value if translation addition is confirmed
+      // 'y' or 'N'
       const confirmation = answers.value;
 
-      if (!confirmation) {
+      if (confirmation === 'N') {
         console.log('Discarding new translation');
         throw new BreakSignal();
       }
@@ -237,7 +237,7 @@ const addTranslation = (targetLang, key, source) => {
  * @param {String} key Key for the new translation
  * @param {Object} source Source language translations
  *
- * @return a Promise with the answers hash containing a boolean value field
+ * @return a Promise with with answers.value being 'y' or 'N'
  */
 const confirmTranslation = (targetLang, key, translation) => {
   return inquirer.prompt([
@@ -247,8 +247,7 @@ const confirmTranslation = (targetLang, key, translation) => {
       message: `Do you want to add the ${targetLangName(targetLang)} translation ${chalk.green(
         translation
       )} for the key ${chalk.blueBright(key)}? (y/N)`,
-      filter: value => (value === 'y' ? true : value === 'N' ? false : value),
-      validate: value => value === true || value === false,
+      validate: value => value === 'y' || value === 'N',
     },
   ]);
 };

--- a/translations.js
+++ b/translations.js
@@ -1,7 +1,12 @@
 /**
  * A translations too that can be used to keep a translation file(s)
  * up to date with one source language file.
+ *
+ * To track new languages add a desired language to the TARGET_LANGS array.
+ * By default the translations are matched agains English translations
+ * but that can be changed by modifying the SOURCE_LANG.
  */
+
 const inquirer = require('inquirer');
 const difference = require('lodash/difference');
 const fs = require('fs');
@@ -139,10 +144,11 @@ const selectKey = (targetLang, diff, source, target) => {
     {
       type: 'list',
       name: 'key',
-      message: `The following translation keys are missing from the ${targetLangName(
+      message: `The following translation keys (${diff.length}) are missing from the ${targetLangName(
         targetLang
       )} translations. Select a key to add a translation.`,
       choices: choices,
+      pageSize: 30,
     },
   ]);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,6 +1512,11 @@ change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
 
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
 charenc@~0.0.1:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
@@ -3005,6 +3010,15 @@ external-editor@^2.0.4:
     jschardet "^1.4.2"
     tmp "^0.0.33"
 
+external-editor@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
+  integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -3819,6 +3833,13 @@ iconv-lite@0.4.23, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -3921,6 +3942,25 @@ inquirer@3.3.0, inquirer@^3.0.6, inquirer@^3.3.0:
     run-async "^2.2.0"
     rx-lite "^4.0.8"
     rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
+    through "^2.3.6"
+
+inquirer@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.0.tgz#51adcd776f661369dc1e894859c2560a224abdd8"
+  integrity sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.0"
+    figures "^2.0.0"
+    lodash "^4.17.10"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^6.1.0"
     string-width "^2.1.0"
     strip-ansi "^4.0.0"
     through "^2.3.6"
@@ -7312,6 +7352,13 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
+rxjs@^6.1.0:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
+  integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.1, safe-buffer@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -8105,6 +8152,11 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
![translations_cli](https://user-images.githubusercontent.com/57473/49023462-ed695f00-f19f-11e8-9c9e-18c4fd0f7da1.gif)

Adds a command line tool that can be used to manage translations:

- see what keys are missing compared to English translations
- add a missing translation

__Testing__

To try the out the tool, copy `src/translations/en.json` to `src/translations/es.json` for example and remove a few lines from the es translations file.