### PR TITLE
NSP is dead and the API no longer resolves - replace with yarn audit.…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             - node_modules/
       - run:
           name: Audit dependencies
-          command: yarn run audit
+          command: yarn audit
 workflows:
   version: 2
   format_test_build_audit:

--- a/package.json
+++ b/package.json
@@ -78,8 +78,7 @@
     "eject": "sharetribe-scripts eject",
     "start": "node server/index.js",
     "dev-server": "export NODE_ENV=development PORT=4000 REACT_APP_CANONICAL_ROOT_URL=http://localhost:4000&&yarn run build&&nodemon --watch server server/index.js",
-    "heroku-postbuild": "yarn run build",
-    "audit": "nsp check --preprocessor yarn"
+    "heroku-postbuild": "yarn run build"
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
… see: https://blog.npmjs.org/post/175511531085/the-node-security-platform-service-is-shutting