### PR TITLE
Fix wrong booking title on listing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2018-XX-XX
 
+- [fix] Fix wrong booking title on listing page that has been introduced in #969.
+  [#987](https://github.com/sharetribe/flex-template-web/pull/987)
 - [fix] yarn.lock file was not up to date
   [#986](https://github.com/sharetribe/flex-template-web/pull/986)
 - [add] Add an image of fork button to the deploy to production guide.

--- a/src/containers/ListingPage/ListingPage.js
+++ b/src/containers/ListingPage/ListingPage.js
@@ -229,9 +229,8 @@ export class ListingPageComponent extends Component {
       </span>
     );
 
-    const bookingTitle = intl.formatMessage(
-      { id: 'ListingPage.bookingSubTitle' },
-      { title: richTitle }
+    const bookingTitle = (
+      <FormattedMessage id="ListingPage.bookingTitle" values={{ title: richTitle }} />
     );
     const bookingSubTitle = intl.formatMessage({ id: 'ListingPage.bookingSubTitle' });
 

--- a/src/containers/ListingPage/__snapshots__/ListingPage.test.js.snap
+++ b/src/containers/ListingPage/__snapshots__/ListingPage.test.js.snap
@@ -307,7 +307,22 @@ exports[`ListingPage matches snapshot 1`] = `
             onSubmit={[Function]}
             subTitle="ListingPage.bookingSubTitle"
             timeSlots={null}
-            title="ListingPage.bookingSubTitle"
+            title={
+              <FormattedMessage
+                id="ListingPage.bookingTitle"
+                values={
+                  Object {
+                    "title": <span>
+                      
+                      listing1
+                       
+                      title
+                      
+                  </span>,
+                  }
+                }
+              />
+            }
             unitType="line-item/night"
           />
         </div>


### PR DESCRIPTION
Fixes wrong title being used for the booking panel on listing page.

So fix this:

![before](https://user-images.githubusercontent.com/57473/50474843-1e20fc00-09cb-11e9-9fa6-d6d6bab5fdda.png)

To this:

![after](https://user-images.githubusercontent.com/57473/50474855-2a0cbe00-09cb-11e9-9a9b-8d237f2b698d.png)
