### PR TITLE
SearchPage.duck.js: endDate should not be expanded for night bookings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] day boundaries for date filter and pass booking state to bookings.query
+  - SearchPage.duck.js: endDate should not be expanded for night bookings
+  - DateRangeController: bookingUnitType: day should allow 0 night
+  - EditListingPage.duck.js booking state should be passed to query
+    [#1016](https://github.com/sharetribe/flex-template-web/pull/1016)
 - [add] Date filter added and filter components (single and multiselect) are refactored to use
   shared subcomponents. [#949](https://github.com/sharetribe/flex-template-web/pull/949)
 - [fix] Fixed copy-text in ReviewForm: Rating is required.

--- a/src/components/FieldDateRangeController/DateRangeController.js
+++ b/src/components/FieldDateRangeController/DateRangeController.js
@@ -55,7 +55,7 @@ const defaultProps = {
   renderDayContents: day => {
     return <span className="renderedDay">{day.format('D')}</span>;
   },
-  minimumNights: 1,
+  minimumNights: config.bookingUnitType === 'line-item/night' ? 1 : 0,
   enableOutsideDays: false,
   isDayBlocked: () => false,
 

--- a/src/containers/EditListingPage/EditListingPage.duck.js
+++ b/src/containers/EditListingPage/EditListingPage.duck.js
@@ -517,13 +517,13 @@ export function requestImageUpload(actionPayload) {
 }
 
 export const requestFetchBookings = fetchParams => (dispatch, getState, sdk) => {
-  const { listingId, start, end } = fetchParams;
+  const { listingId, start, end, state } = fetchParams;
   const monthId = monthIdString(start);
 
   dispatch(fetchBookingsRequest({ ...fetchParams, monthId }));
 
   return sdk.bookings
-    .query({ listingId, start, end }, { expand: true })
+    .query({ listingId, start, end, state }, { expand: true })
     .then(response => {
       const bookings = denormalisedResponseEntities(response);
       return dispatch(fetchBookingsSuccess({ data: { monthId, bookings } }));

--- a/src/containers/SearchPage/SearchPage.duck.js
+++ b/src/containers/SearchPage/SearchPage.duck.js
@@ -136,7 +136,9 @@ export const searchListings = searchParams => (dispatch, getState, sdk) => {
     const values = datesParam ? datesParam.split(',') : [];
     const hasValues = datesParam && values.length === 2;
     const startDate = hasValues ? values[0] : null;
-    const endDate = hasValues ? getExclusiveEndDate(values[1]) : null;
+    const isNightlyBooking = config.bookingUnitType === 'line-item/night';
+    const endDate =
+      hasValues && isNightlyBooking ? values[1] : hasValues ? getExclusiveEndDate(values[1]) : null;
 
     return hasValues
       ? {


### PR DESCRIPTION
- SearchPage.duck.js: endDate should not be expanded for night bookings
- DateRangeController: bookingUnitType: day should allow 0 night
- EditListingPage.duck.js booking state should be passed to query