### PR TITLE
Release v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+## [v2.9.0] 2019-01-29
+
 - [fix] day boundaries for date filter and pass booking state to bookings.query
   - SearchPage.duck.js: endDate should not be expanded for night bookings
   - DateRangeController: bookingUnitType: day should allow 0 night
@@ -43,6 +45,8 @@ way to update this template, but currently, we follow a pattern:
 - [add] Limit location autocomplete by adding an optional country parameter to geocoding call in
   both Mapbox and Google Maps integrations. Also updated Mapbox SDK to version 0.5.0.
   [#1002](https://github.com/sharetribe/flex-template-web/pull/1002)
+
+  [v2.9.0]: https://github.com/sharetribe/flex-template-web/compare/v2.8.0...v2.9.0
 
 ## [v2.8.0] 2019-01-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
:tada: A new FTW release: v2.9.0
https://github.com/sharetribe/flex-template-web/releases/tag/v2.9.0

The biggest feature in this release is date filter. You can filter *night* and *day* based listings using start and end dates. 

This feature is using the newest changes to the listing query in Marketplace API.
https://flex-docs.sharetribe.com/changelog.html#2019-01-28
https://flex-docs.sharetribe.com/#query-listings

Currently, date search is set to return only listings that are fully available during the given date range, but this can be change to include also partial availability.
https://github.com/sharetribe/flex-template-web/blob/master/src/containers/SearchPage/SearchPage.duck.js#L146

Other changes:
- **Limit location autocomplete by adding an optional country parameter to geocoding call** in
  both Mapbox and Google Maps integrations.
- Some of the documentation moved to Flex Docs: https://www.sharetribe.com/docs/
- Our translation process has changed a bit. Non-english translations now default to English. (E.g. fr.json gets default translations from en.json if there are missing keys.) New releases should include all the translations.
- Removed origin from `default-location-searches.js` to make it easier to change those searchs.
- fixed small bugs and copy-text changes. 
