### PR TITLE
Sent correct params in user.duck.js depending on Stripe API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] Fix to PR [#1035](https://github.com/sharetribe/flex-template-web/pull/1035). In
+  `user.duck.js` send correct params depending on Stripe API in use.
+  [#1037](https://github.com/sharetribe/flex-template-web/pull/1037)
 - [change] Update creating Stripe account token to support the latest Stripe API update. See also
   [Stripe API changelog](https://stripe.com/docs/upgrades#api-changelog). **IMPORTANT:** If you are
   using a Stripe account created earlier than 19th of February 2019 you need to change the value of

--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -391,7 +391,7 @@ export const createStripeAccount = payoutDetails => (dispatch, getState, sdk) =>
   let payoutDetailValues;
   if (accountType === 'company') {
     payoutDetailValues = payoutDetails['company'];
-  } else if (accountType === 'individual') {
+  } else {
     payoutDetailValues = payoutDetails['individual'];
   }
 
@@ -457,9 +457,8 @@ export const createStripeAccount = payoutDetails => (dispatch, getState, sdk) =>
   // edit 'useDeprecatedLegalEntityWithStripe' config in the stripe-config.js
 
   const isNewAPI = !config.stripe.useDeprecatedLegalEntityWithStripe;
-  const isIndividualAccount = accountType === 'individual';
 
-  if (isNewAPI && isIndividualAccount) {
+  if (isNewAPI) {
     params = {
       business_type: 'individual',
       individual: {
@@ -471,8 +470,6 @@ export const createStripeAccount = payoutDetails => (dispatch, getState, sdk) =>
       },
       tos_shown_and_accepted: true,
     };
-  } else if (isNewAPI && !isIndividualAccount) {
-    // TODO new company accounst
   } else {
     params = {
       legal_entity: {


### PR DESCRIPTION
Fix to PR [#1035](https://github.com/sharetribe/flex-template-web/pull/1035). In
  `user.duck.js` send correct params depending on Stripe API in use.