### PR TITLE
Fix fieldbirthdayinput placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] FieldBirthdayInput: placeholder text was not selected by default.
+  [#1039](https://github.com/sharetribe/flex-template-web/pull/1039)
+
 ## [v2.12.0] 2019-02-28
 
 - [fix] Fix to PR [#1035](https://github.com/sharetribe/flex-template-web/pull/1035). In

--- a/src/components/FieldBirthdayInput/FieldBirthdayInput.js
+++ b/src/components/FieldBirthdayInput/FieldBirthdayInput.js
@@ -155,7 +155,9 @@ class BirthdayInputComponent extends Component {
             onBlur={() => this.handleSelectBlur()}
             onChange={e => this.handleSelectChange('day', e.target.value)}
           >
-            <option disabled>{datePlaceholder}</option>
+            <option disabled value="">
+              {datePlaceholder}
+            </option>
             {days.map(d => (
               <option key={d} value={d}>
                 {pad(d)}
@@ -176,7 +178,9 @@ class BirthdayInputComponent extends Component {
             onBlur={() => this.handleSelectBlur()}
             onChange={e => this.handleSelectChange('month', e.target.value)}
           >
-            <option disabled>{monthPlaceholder}</option>
+            <option disabled value="">
+              {monthPlaceholder}
+            </option>
             {months.map(m => (
               <option key={m} value={m}>
                 {pad(m)}
@@ -197,7 +201,9 @@ class BirthdayInputComponent extends Component {
             onBlur={() => this.handleSelectBlur()}
             onChange={e => this.handleSelectChange('year', e.target.value)}
           >
-            <option disabled>{yearPlaceholder}</option>
+            <option disabled value="">
+              {yearPlaceholder}
+            </option>
             {years.map(y => (
               <option key={y} value={y}>
                 {y}


### PR DESCRIPTION
Placeholder option was not selected by default anymore but the first real value (e.g. 01), which caused problems if a user tried to select the first day of the month or January.

This bug has probably emerged after updating React or Final Form. 
React works so that if you pass a value to `<select>` component, related `<option>` will become selected. We didn't have any value set to placeholder `<option>` elements.