### PR TITLE
Remove node engine setup

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,35 +4,32 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Describe the bug** A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+**To Reproduce** Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+**Expected behavior** A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Screenshots** If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
 
-**Additional context**
-Add any other context about the problem here.
+- Device: [e.g. iPhone6]
+- OS: [e.g. iOS8.1]
+- Browser [e.g. stock browser, safari]
+- Version [e.g. 22]
+
+**Additional context** Add any other context about the problem here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
-- [Fix] Add error handling to `PayoutDetailsForm` and `StripePaymentForm` in case Stripe publishable
+- [change] Removed Node-engine setup from package.json. Fixed version was causing problems for quite
+  many in their first FTW installation. Note: when troubleshooting your Heroku installation, you
+  might want to reintroduce engine setup.
+  [#1043](https://github.com/sharetribe/flex-template-web/pull/1043)
+- [fix] Add error handling to `PayoutDetailsForm` and `StripePaymentForm` in case Stripe publishable
   key is not configured yet. [#1042](https://github.com/sharetribe/flex-template-web/pull/1042)
 - [fix] FieldBirthdayInput: placeholder text was not selected by default.
   [#1039](https://github.com/sharetribe/flex-template-web/pull/1039)

--- a/package.json
+++ b/package.json
@@ -86,8 +86,5 @@
     "singleQuote": true,
     "trailingComma": "es5",
     "proseWrap": "always"
-  },
-  "engines": {
-    "node": "10.14"
   }
 }


### PR DESCRIPTION
Fixed engine was causing problems with most installations, so we decided to remove it.

However, you might want to reintroduce it if you are troubleshooting your staging/production environment in Heroku:
https://www.sharetribe.com/docs/guides/how-to-deploy-ftw-to-production/#troubleshooting-heroku