### PR TITLE
Fix empty slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] A listing title that contained only stripped-off characters caused bugs in slug / pathName
+  generation. [#1048](https://github.com/sharetribe/flex-template-web/pull/1048)
 - [change] Removed Node-engine setup from package.json. Fixed version was causing problems for quite
   many in their first FTW installation. Note: when troubleshooting your Heroku installation, you
   might want to reintroduce engine setup.

--- a/src/util/routes.js
+++ b/src/util/routes.js
@@ -20,8 +20,11 @@ const toPathByRouteName = (nameToFind, routes) => {
 /**
  * Shorthand for single path call. (```pathByRouteName('ListingPage', routes, { id: uuidX });```)
  */
-export const pathByRouteName = (nameToFind, routes, params = {}) =>
-  toPathByRouteName(nameToFind, routes)(params);
+export const pathByRouteName = (nameToFind, routes, params = {}) => {
+  const hasEmptySlug = params && params.hasOwnProperty('slug') && params.slug === '';
+  const pathParams = hasEmptySlug ? { ...params, slug: 'no-slug' } : params;
+  return toPathByRouteName(nameToFind, routes)(pathParams);
+};
 
 /**
  * Find the matching routes and their params for the given pathname

--- a/src/util/urlHelpers.js
+++ b/src/util/urlHelpers.js
@@ -55,7 +55,7 @@ export const createSlug = str => {
     text = text.replace(new RegExp(`[${set.from}]`, 'gi'), set.to);
   });
 
-  return encodeURIComponent(
+  const slug = encodeURIComponent(
     text
       .replace(/\s+/g, '-') // Replace spaces with -
       .replace(/[^\w-]+/g, '') // Remove all non-word chars
@@ -63,6 +63,8 @@ export const createSlug = str => {
       .replace(/^-+/, '') // Trim - from start of text
       .replace(/-+$/, '') // Trim - from end of text
   );
+
+  return slug.length > 0 ? slug : 'no-slug';
 };
 
 /**

--- a/src/util/urlHelpers.test.js
+++ b/src/util/urlHelpers.test.js
@@ -18,7 +18,7 @@ const COMMA = encodeURIComponent(',');
 describe('urlHelpers', () => {
   describe('parseFloatNum()', () => {
     it('handles empty string (returns "")', () => {
-      expect(createSlug('')).toEqual('');
+      expect(createSlug('')).toEqual('no-slug');
     });
 
     it('handles space characters', () => {


### PR DESCRIPTION
A listing title that contained only stripped-off characters caused bugs in slug / pathName generation.

Longer version:
If a provider creates a listing with a title that only contains characters that we strip-off when creating a slug for URLs, It will cause an error and a blank page (or 500 if server rendered). (E.g. title like "--")
This can happen in search page too.