### PR TITLE
New release: v2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+## [v2.13.0] 2019-03-28
+
 - [add] Add translations for recent Stripe API related changes. (German will be included later.)
   [#1052](https://github.com/sharetribe/flex-template-web/pull/1052)
 - [fix] JPY currency was configured wrongly: it doesn't use subunits.
@@ -37,6 +39,8 @@ way to update this template, but currently, we follow a pattern:
 - [fix] FieldBirthdayInput: placeholder text was not selected by default.
   [#1039](https://github.com/sharetribe/flex-template-web/pull/1039)
 
+  [v2.13.0]: https://github.com/sharetribe/flex-template-web/compare/v2.12.1...v2.13.0
+
 ## [v2.12.0] 2019-02-28
 
 - [fix] Fix to PR [#1035](https://github.com/sharetribe/flex-template-web/pull/1035). In
@@ -57,7 +61,7 @@ way to update this template, but currently, we follow a pattern:
   refactored to work with `rootClassName` prop (PrimaryButton, SecondaryButton and
   InlineTextButton). [#1024](https://github.com/sharetribe/flex-template-web/pull/1024)
 
-  [v2.11.0]: https://github.com/sharetribe/flex-template-web/compare/v2.11.1...v2.12.0
+  [v2.12.0]: https://github.com/sharetribe/flex-template-web/compare/v2.11.1...v2.12.0
 
 ## [v2.11.1] 2019-02-21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## v2.13.0 - 2019-03-28

- [add] Add translations for recent Stripe API related changes. (German will be included later.)
  [#1052](https://github.com/sharetribe/flex-template-web/pull/1052)
- [fix] JPY currency was configured wrongly: it doesn't use subunits.
  [#1051](https://github.com/sharetribe/flex-template-web/pull/1051)
- [add] **Complete rewrite to `PayoutDetailsForm` due to breaking changes in Stripe API.**
  [#1049](https://github.com/sharetribe/flex-template-web/pull/1049)
  - You should track all your customizations to `PayoutDetailsForm` and related changes in
    `user.duck.js` and elsewhere before merging this upstream-update.
  - You should update Stripe API to "2019-02-19" or later
- [add] Booking: use attributes `displayStart` and `displayEnd`, instead of reading booking period
  directly from `start` and `end` attributes.
  [#1050](https://github.com/sharetribe/flex-template-web/pull/1050)
- [fix] A listing title that contained only stripped-off characters caused bugs in slug / pathName
  generation. [#1048](https://github.com/sharetribe/flex-template-web/pull/1048)
- [change] Removed Node-engine setup from package.json. Fixed version was causing problems for quite
  many in their first FTW installation. Note: when troubleshooting your Heroku installation, you
  might want to reintroduce engine setup.
  [#1043](https://github.com/sharetribe/flex-template-web/pull/1043)
- [fix] Add error handling to `PayoutDetailsForm` and `StripePaymentForm` in case Stripe publishable
  key is not configured yet. [#1042](https://github.com/sharetribe/flex-template-web/pull/1042)
- [fix] FieldBirthdayInput: placeholder text was not selected by default.
  [#1039](https://github.com/sharetribe/flex-template-web/pull/1039)
