### PR TITLE
Fix bug page got crashed when refresh EditListingPage in development mode

### DIFF
--- a/src/components/EditListingWizard/EditListingWizard.js
+++ b/src/components/EditListingWizard/EditListingWizard.js
@@ -10,7 +10,7 @@ import {
   LISTING_PAGE_PARAM_TYPE_NEW,
   LISTING_PAGE_PARAM_TYPES,
 } from '../../util/urlHelpers';
-import { ensureListing } from '../../util/data';
+import { ensureListing, ensureCurrentUser } from '../../util/data';
 import { PayoutDetailsForm } from '../../forms';
 import { Modal, NamedRedirect, Tabs } from '../../components';
 
@@ -288,7 +288,7 @@ class EditListingWizard extends Component {
               className={css.payoutDetails}
               inProgress={fetchInProgress}
               createStripeAccountError={errors ? errors.createStripeAccountError : null}
-              currentUserId={this.props.currentUser.id}
+              currentUserId={ensureCurrentUser(this.props.currentUser).id}
               onChange={onPayoutDetailsFormChange}
               onSubmit={this.handlePayoutSubmit}
             />


### PR DESCRIPTION
Cause: `currentUser` is `null` when the `EditListingPage` got reloaded. So when you try to pass in the `currentUser.id` to the `PayoutDetailsForm, the page got crashed in development mode.
Solve: ensure current user and then pass in ID