### PR TITLE
New release: v2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,15 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+## [v2.13.1] 2019-03-29
+
 - [add] a comment about category and amenities filters. They don't work out-of-the-box, extended
   data needs a schema before it can work as a search filter.
   [#1055](https://github.com/sharetribe/flex-template-web/pull/1055)
 - [fix] EditListingWizard: currentUser was null when the EditListingPage got reloaded causing
   TypeError. [#1056](https://github.com/sharetribe/flex-template-web/pull/1056)
+
+  [v2.13.1]: https://github.com/sharetribe/flex-template-web/compare/v2.13.0...v2.13.1
 
 ## [v2.13.0] 2019-03-28
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.13.0",
+  "version": "2.13.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## v2.13.1

- [add] a comment about category and amenities filters. They don't work out-of-the-box, extended
  data needs a schema before it can work as a search filter.
  [#1055](https://github.com/sharetribe/flex-template-web/pull/1055)
- [fix] EditListingWizard: currentUser was null when the EditListingPage got reloaded causing
  TypeError. [#1056](https://github.com/sharetribe/flex-template-web/pull/1056)