### PR TITLE
Fix port on sitemap draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] Get port info from `process.env.PORT`.
+  [#1060](https://github.com/sharetribe/flex-template-web/pull/1060)
+
 ## [v2.13.1] 2019-03-29
 
 - [add] a comment about category and amenities filters. They don't work out-of-the-box, extended

--- a/server/sitemap.js
+++ b/server/sitemap.js
@@ -31,18 +31,6 @@ const domain = rootURL => {
 };
 
 /**
- * Resolves the port number from a URL. If the port
- * can not be found `undefined` will be returned.
- */
-const port = rootURL => {
-  if (!rootURL) {
-    return 'INVALID_URL';
-  }
-
-  return domainAndPort(rootURL).split(':')[1];
-};
-
-/**
  * Return a structure for sitemap.xml and robots.txt to be used by the
  * express-sitemap library. Uses the canonical URL value from env
  * config for domain and port information.
@@ -53,7 +41,7 @@ exports.sitemapStructure = () => {
   return {
     url: domain(process.env.REACT_APP_CANONICAL_ROOT_URL),
     http: USING_SSL ? 'https' : 'http',
-    port: port(process.env.REACT_APP_CANONICAL_ROOT_URL),
+    port: process.env.PORT,
     sitemap: path.join(buildPath, 'static', 'sitemap.xml'),
     robots: path.join(buildPath, 'robots.txt'),
     sitemapSubmission: '/static/sitemap.xml',


### PR DESCRIPTION
Closing this: if port is passed in for express-sitemap on production, it will use it - and this causes problems on Heroku-like proxy setup...