### PR TITLE
Fix individual account url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] US individual accounts had a non-editable business url in PayoutDetailsForm. It was probably
+  OK, but there wasn't any reason to for it.
+  [#1061](https://github.com/sharetribe/flex-template-web/pull/1061)
+
 ## [v2.13.1] 2019-03-29
 
 - [add] a comment about category and amenities filters. They don't work out-of-the-box, extended

--- a/src/forms/PayoutDetailsForm/PayoutDetailsIndividualAccount.js
+++ b/src/forms/PayoutDetailsForm/PayoutDetailsIndividualAccount.js
@@ -33,7 +33,11 @@ const PayoutDetailsIndividualAccountComponent = props => {
   const showMCCForUSField = !!individualConfig.mccForUS;
   const showBusinssProfileSection = showBusinessURLField || showMCCForUSField;
 
-  const hasBusinessURL = values && values.businessProfile && values.businessProfile.url;
+  const hasBusinessURL =
+    values &&
+    values.individual &&
+    values.individual.businessProfile &&
+    values.individual.businessProfile.url;
 
   // Use user profile page as business_url on this marketplace
   // or just fake it if it's dev environment using Stripe test endpoints.


### PR DESCRIPTION
US individual accounts had a non-editable business URL in PayoutDetailsForm. This essentially buggy setup was probably OK behaviour, but there wasn't any reason for not letting individuals to change the URL to some other site (the default is user's profile page).