### PR TITLE
SearchPage: use sparse fields to improve query performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [add] Use sparse fields on SearchPage to reduce data load.
+  [#1066](https://github.com/sharetribe/flex-template-web/pull/1066)
+  - NOTE: if you need more fields on `ListingCard` than title, price and geolocation - you need to
+    add those to `loadData` function.
+
 ## [v2.14.0] 2019-04-05
 
 - [add] German translations for recent PayoutDetailsForm changes.

--- a/src/components/BookingPanel/BookingPanel.js
+++ b/src/components/BookingPanel/BookingPanel.js
@@ -69,7 +69,9 @@ const BookingPanel = props => {
   } = props;
 
   const price = listing.attributes.price;
-  const isClosed = listing.attributes.state === LISTING_STATE_CLOSED;
+  const hasListingState = !!listing.attributes.state;
+  const isClosed = hasListingState && listing.attributes.state === LISTING_STATE_CLOSED;
+  const showBookingDatesForm = hasListingState && !isClosed;
   const showClosedListingHelpText = listing.id && isClosed;
   const { formattedPrice, priceTitle } = priceData(price, intl);
   const isBook = !!parse(location.search).book;
@@ -113,7 +115,7 @@ const BookingPanel = props => {
           <h2 className={titleClasses}>{title}</h2>
           {subTitleText ? <div className={css.bookingHelp}>{subTitleText}</div> : null}
         </div>
-        {!isClosed ? (
+        {showBookingDatesForm ? (
           <BookingDatesForm
             className={css.bookingForm}
             submitButtonWrapperClassName={css.bookingDatesSubmitButtonWrapper}
@@ -136,7 +138,7 @@ const BookingPanel = props => {
           </div>
         </div>
 
-        {!isClosed ? (
+        {showBookingDatesForm ? (
           <Button
             rootClassName={css.bookButton}
             onClick={() => openBookModal(isOwnListing, isClosed, history, location)}

--- a/src/containers/ListingPage/ListingPage.js
+++ b/src/containers/ListingPage/ListingPage.js
@@ -45,9 +45,9 @@ import SectionImages from './SectionImages';
 import SectionAvatar from './SectionAvatar';
 import SectionHeading from './SectionHeading';
 import SectionDescriptionMaybe from './SectionDescriptionMaybe';
-import SectionFeatures from './SectionFeatures';
+import SectionFeaturesMaybe from './SectionFeaturesMaybe';
 import SectionReviews from './SectionReviews';
-import SectionHost from './SectionHost';
+import SectionHostMaybe from './SectionHostMaybe';
 import SectionRulesMaybe from './SectionRulesMaybe';
 import SectionMapMaybe from './SectionMapMaybe';
 import css from './ListingPage.css';
@@ -303,7 +303,7 @@ export class ListingPageComponent extends Component {
     const userAndListingAuthorAvailable = !!(currentUser && authorAvailable);
     const isOwnListing =
       userAndListingAuthorAvailable && currentListing.author.id.uuid === currentUser.id.uuid;
-    const showContactUser = !currentUser || (currentUser && !isOwnListing);
+    const showContactUser = authorAvailable && (!currentUser || (currentUser && !isOwnListing));
 
     const currentAuthor = authorAvailable ? currentListing.author : null;
     const ensuredAuthor = ensureUser(currentAuthor);
@@ -416,10 +416,7 @@ export class ListingPageComponent extends Component {
                     onContactUser={this.onContactUser}
                   />
                   <SectionDescriptionMaybe description={description} />
-                  <SectionFeatures
-                    options={amenitiesConfig}
-                    selectedOptions={publicData.amenities}
-                  />
+                  <SectionFeaturesMaybe options={amenitiesConfig} publicData={publicData} />
                   <SectionRulesMaybe publicData={publicData} />
                   <SectionMapMaybe
                     geolocation={geolocation}
@@ -427,7 +424,7 @@ export class ListingPageComponent extends Component {
                     listingId={currentListing.id}
                   />
                   <SectionReviews reviews={reviews} fetchReviewsError={fetchReviewsError} />
-                  <SectionHost
+                  <SectionHostMaybe
                     title={title}
                     listing={currentListing}
                     authorDisplayName={authorDisplayName}

--- a/src/containers/ListingPage/SectionFeaturesMaybe.js
+++ b/src/containers/ListingPage/SectionFeaturesMaybe.js
@@ -4,8 +4,13 @@ import { PropertyGroup } from '../../components';
 
 import css from './ListingPage.css';
 
-const SectionFeatures = props => {
-  const { options, selectedOptions } = props;
+const SectionFeaturesMaybe = props => {
+  const { options, publicData } = props;
+  if (!publicData) {
+    return null;
+  }
+
+  const selectedOptions = publicData && publicData.amenities ? publicData.amenities : [];
   return (
     <div className={css.sectionFeatures}>
       <h2 className={css.featuresTitle}>
@@ -21,4 +26,4 @@ const SectionFeatures = props => {
   );
 };
 
-export default SectionFeatures;
+export default SectionFeaturesMaybe;

--- a/src/containers/ListingPage/SectionHostMaybe.js
+++ b/src/containers/ListingPage/SectionHostMaybe.js
@@ -5,7 +5,7 @@ import { EnquiryForm } from '../../forms';
 
 import css from './ListingPage.css';
 
-const SectionHost = props => {
+const SectionHostMaybe = props => {
   const {
     title,
     listing,
@@ -19,6 +19,11 @@ const SectionHost = props => {
     currentUser,
     onManageDisableScrolling,
   } = props;
+
+  if (!listing.author) {
+    return null;
+  }
+
   return (
     <div id="host" className={css.sectionHost}>
       <h2 className={css.yourHostHeading}>
@@ -46,4 +51,4 @@ const SectionHost = props => {
   );
 };
 
-export default SectionHost;
+export default SectionHostMaybe;

--- a/src/containers/ListingPage/SectionMapMaybe.js
+++ b/src/containers/ListingPage/SectionMapMaybe.js
@@ -22,7 +22,7 @@ class SectionMapMaybe extends Component {
       return null;
     }
 
-    const address = publicData.location ? publicData.location.address : '';
+    const address = publicData && publicData.location ? publicData.location.address : '';
     const classes = classNames(rootClassName || css.sectionMap, className);
     const cacheKey = listingId ? `${listingId.uuid}_${geolocation.lat}_${geolocation.lng}` : null;
 

--- a/src/containers/ListingPage/SectionRulesMaybe.js
+++ b/src/containers/ListingPage/SectionRulesMaybe.js
@@ -8,7 +8,7 @@ import css from './SectionRulesMaybe.css';
 const SectionRulesMaybe = props => {
   const { className, rootClassName, publicData } = props;
   const classes = classNames(rootClassName || css.root, className);
-  return publicData.rules ? (
+  return publicData && publicData.rules ? (
     <div className={classes}>
       <h2 className={css.title}>
         <FormattedMessage id="ListingPage.rulesTitle" />
@@ -25,7 +25,7 @@ SectionRulesMaybe.propTypes = {
   rootClassName: string,
   publicData: shape({
     rules: string,
-  }).isRequired,
+  }),
 };
 
 export default SectionRulesMaybe;

--- a/src/containers/ListingPage/__snapshots__/ListingPage.test.js.snap
+++ b/src/containers/ListingPage/__snapshots__/ListingPage.test.js.snap
@@ -152,7 +152,7 @@ exports[`ListingPage matches snapshot 1`] = `
             <SectionDescriptionMaybe
               description="listing1 description"
             />
-            <SectionFeatures
+            <SectionFeaturesMaybe
               options={
                 Array [
                   Object {
@@ -169,6 +169,7 @@ exports[`ListingPage matches snapshot 1`] = `
                   },
                 ]
               }
+              publicData={Object {}}
             />
             <SectionRulesMaybe
               className={null}
@@ -195,7 +196,7 @@ exports[`ListingPage matches snapshot 1`] = `
               fetchReviewsError={null}
               reviews={Array []}
             />
-            <SectionHost
+            <SectionHostMaybe
               authorDisplayName="user-1 display name"
               currentUser={
                 Object {

--- a/src/containers/SearchPage/SearchPage.js
+++ b/src/containers/SearchPage/SearchPage.js
@@ -366,6 +366,8 @@ SearchPage.loadData = (params, search) => {
     page,
     perPage: RESULT_PAGE_SIZE,
     include: ['author', 'images'],
+    'fields.listing': ['title', 'geolocation', 'price'],
+    'fields.user': ['profile.displayName', 'profile.abbreviatedName'],
     'fields.image': ['variants.landscape-crop', 'variants.landscape-crop2x'],
     'limit.images': 1,
   });

--- a/src/util/types.js
+++ b/src/util/types.js
@@ -118,6 +118,17 @@ const userAttributes = shape({
   }),
 });
 
+// Listing queries can include author.
+// Banned and deleted are not relevant then
+// since banned and deleted users can't have listings.
+const authorAttributes = shape({
+  profile: shape({
+    displayName: string.isRequired,
+    abbreviatedName: string.isRequired,
+    bio: string,
+  }),
+});
+
 const deletedUserAttributes = shape({
   deleted: propTypes.value(true).isRequired,
 });
@@ -130,7 +141,12 @@ const bannedUserAttributes = shape({
 propTypes.user = shape({
   id: propTypes.uuid.isRequired,
   type: propTypes.value('user').isRequired,
-  attributes: oneOfType([userAttributes, deletedUserAttributes, bannedUserAttributes]).isRequired,
+  attributes: oneOfType([
+    userAttributes,
+    authorAttributes,
+    deletedUserAttributes,
+    bannedUserAttributes,
+  ]).isRequired,
   profileImage: propTypes.image,
 });
 
@@ -148,12 +164,12 @@ const LISTING_STATES = [
 
 const listingAttributes = shape({
   title: string.isRequired,
-  description: string.isRequired,
+  description: string,
   geolocation: propTypes.latlng,
-  deleted: propTypes.value(false).isRequired,
-  state: oneOf(LISTING_STATES).isRequired,
+  deleted: propTypes.value(false),
+  state: oneOf(LISTING_STATES),
   price: propTypes.money,
-  publicData: object.isRequired,
+  publicData: object,
 });
 
 const AVAILABILITY_PLAN_DAY = 'availability-plan/day';


### PR DESCRIPTION
**NOTE:** If you have changed `ListingCard` component, check if any data is missing on `SearchPage`. This deliberately drops some of the fields of Listing entity away from template.

This improves SearchPage performance a bit by reducing the amount of fetched data. It also serves as an example of how to use sparse fields:
```js
    'fields.listing': ['title', 'geolocation', 'price'],
    'fields.user': ['profile.displayName', 'profile.abbreviatedName'],
```

This change also improved `ListingPage` a bit, since we were making assumptions of certain data to be unnecessarily required.

There are 2 renamed files in `src/containers/ListingPage/`:
`SectionFeatures.js` -> `SectionFeaturesMaybe.js`
`SectionHost.js` -> `SectionHostMaybe.js`