### PR TITLE
Add audit alerts to exception list

### DIFF
--- a/.auditrc
+++ b/.auditrc
@@ -11,4 +11,24 @@ exports.exceptions = [
   // Severity: high, webpack-dev-server (< 3.1.10), (CRA fork)
   // Note: don't run webpack-dev-server on public web.
   "https://npmjs.com/advisories/725",
+
+  // Severity: high, handlebars (< 4.1.2), (CRA fork)
+  // Note: this is about Jest i.e. tests
+  "https://npmjs.com/advisories/755",
+
+  // Severity: moderate, lodash (< 4.17.11), (CRA fork)
+  // Note: this is mainly about Jest/tests and deps used in build
+  "https://npmjs.com/advisories/782",
+
+  // Severity: low, braces (< 2.3.1), (CRA fork)
+  // Note: this is about Jest and dev server
+  "https://npmjs.com/advisories/786",
+
+  // Severity: moderate, js-yaml (< 3.13.0), (CRA fork)
+  // Note: this called in deps used in build
+  "https://npmjs.com/advisories/788",
+
+  // Severity: high, js-yaml (< 3.13.1), (CRA fork)
+  // Note: this is called in deps used in build
+  "https://npmjs.com/advisories/813",
 ];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
-- [fix] ListingPage.duck: fix minor bug on dispatching the fetchReviewsRequest action [#1074](https://github.com/sharetribe/flex-template-web/pull/1074)
+- [fix] New npm vulnerability alerts checked and added to exception list.
+  [#1075](https://github.com/sharetribe/flex-template-web/pull/1075)
+- [fix] ListingPage.duck: fix minor bug on dispatching the fetchReviewsRequest action
+  [#1074](https://github.com/sharetribe/flex-template-web/pull/1074)
 
 ## [v2.15.0] 2019-04-24
 
@@ -27,6 +30,7 @@ way to update this template, but currently, we follow a pattern:
   - NOTE: if you need more fields on `InboxPage`, you need to add those to `loadData` function.
 - [add] Use sparse fields on SearchPage to reduce data load.
   [#1066](https://github.com/sharetribe/flex-template-web/pull/1066)
+
   - NOTE: if you need more fields on `ListingCard` than title, price and geolocation - you need to
     add those to `loadData` function.
 


### PR DESCRIPTION
`yarn run audit` script returned new vulnerability warnings.

Those vulnerable dependencies seemed to be used by libs in test and build phase.

> Side note: we are in the process of updating `sharetribe-scripts` aka our Create React App (CRA) fork soonish. It should help with these warnings. (There are 2 updates coming, [CRA v2.1.8 update](https://github.com/sharetribe/flex-template-web/pull/1073) and CRA v3.0.0 (hopefully). The latter was released a week ago.)