### PR TITLE
Use proper method for unsetting Sentry user context on logout

### DIFF
--- a/src/util/log.js
+++ b/src/util/log.js
@@ -43,7 +43,7 @@ export const setUserId = userId => {
 
 export const clearUserId = () => {
   Sentry.configureScope(scope => {
-    scope.remove_user();
+    scope.setUser(null);
   });
 };
 


### PR DESCRIPTION
Current implementation causes an error popup on logout if Sentry is enabled. This is because `remove_user` is not a valid method on the `scope` object. Changing to use the `setUser` with a `null` parameter as discussed here - https://github.com/getsentry/sentry-docs/issues/500