### PR TITLE
Check that lineItems exists in transaction attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] Ensure on `TransactionPage` that all the required data is loaded before showing the page.
+  [#1080](https://github.com/sharetribe/flex-template-web/pull/1080),
+- [fix] Use proper method for Sentry on logout to avoid error message.
+  [#1082](https://github.com/sharetribe/flex-template-web/pull/1082)
 - [change] Update sharetribe-scripts (CRA fork) to v2.1.8. There are a couple of changes that you
   should check from [#1073](https://github.com/sharetribe/flex-template-web/pull/1073)
   - package.json has now a "browserlist" configuration key. This gives you an option to affect

--- a/src/containers/TransactionPage/TransactionPage.js
+++ b/src/containers/TransactionPage/TransactionPage.js
@@ -118,6 +118,7 @@ export const TransactionPageComponent = props => {
     currentUser &&
     currentTransaction.id &&
     currentTransaction.id.uuid === params.id &&
+    currentTransaction.attributes.lineItems &&
     currentTransaction.customer &&
     currentTransaction.provider &&
     !fetchTransactionError;


### PR DESCRIPTION
When the user comes to transaction page for the second time trough inbox all the required data is not loaded. By checking that `currentTransaction.attributes.lineItems` exists we can avoid that situation. 