### PR TITLE
Fix stripe connected check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
-- [fix] Edit `updatedEntities` function in `util/data.js` so that it doesn't mutate the `oldEntities`
-  argument. [#1079](https://github.com/sharetribe/flex-template-web/pull/1079)
+- [fix] Previous change from `currentUser.attributes.stripeConnected` to separately included
+  `stripeAccount` caused errors since updates to currentUser entity didn't include `stripeAccount`.
+  Including it every time sounds quite error-prone, so we reversed that change.
+  [#1084](https://github.com/sharetribe/flex-template-web/pull/1084)
+- [fix] Edit `updatedEntities` function in `util/data.js` so that it doesn't mutate the
+  `oldEntities` argument. [#1079](https://github.com/sharetribe/flex-template-web/pull/1079)
 - [change] Update sharetribe-scripts (CRA fork) to v3.0.0. There are a couple of changes that you
   should check from [#1081](https://github.com/sharetribe/flex-template-web/pull/1081)
   - Reserve use\* function naming pattern for React Hooks.

--- a/src/components/ModalMissingInformation/ModalMissingInformation.js
+++ b/src/components/ModalMissingInformation/ModalMissingInformation.js
@@ -78,7 +78,7 @@ class ModalMissingInformation extends Component {
       const emailUnverified = !!currentUser.id && !currentUser.attributes.emailVerified;
       const emailVerificationNeeded = hasListingsOrOrders && emailUnverified;
 
-      const stripeAccountMissing = !!currentUser.id && !currentUser.stripeAccount;
+      const stripeAccountMissing = !!currentUser.id && !currentUser.attributes.stripeConnected;
       const stripeAccountNeeded = currentUserHasListings && stripeAccountMissing;
 
       // Show reminder

--- a/src/util/types.js
+++ b/src/util/types.js
@@ -104,6 +104,7 @@ propTypes.currentUser = shape({
       abbreviatedName: string.isRequired,
       bio: string,
     }).isRequired,
+    stripeConnected: bool,
   }),
   profileImage: propTypes.image,
 });


### PR DESCRIPTION
Previous change from `currentUser.attributes.stripeConnected` to separately included
  `stripeAccount` caused errors since updates to currentUser entity didn't include `stripeAccount`.
  Including it every time sounds quite error-prone, so we reversed that change.