### PR TITLE
Fix charge disabled error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] missing provider information (like SSN in US), might cause payment to fail on
+  `CheckoutPage`. This improves related error message.
+  [#10967](https://github.com/sharetribe/flex-template-web/pull/1097)
 - [fix] Menu needs to wait for mounting to calculate dimensions properly.
   [#1096](https://github.com/sharetribe/flex-template-web/pull/1096)
 - [fix] Renamed Component.example.css files to ComponentExample.css to fix bug introduced in one of

--- a/src/containers/CheckoutPage/CheckoutPage.js
+++ b/src/containers/CheckoutPage/CheckoutPage.js
@@ -16,6 +16,7 @@ import {
   isTransactionInitiateListingNotFoundError,
   isTransactionInitiateMissingStripeAccountError,
   isTransactionInitiateBookingTimeNotAvailableError,
+  isTransactionChargeDisabledError,
   isTransactionZeroPaymentError,
   transactionInitiateOrderStripeErrors,
 } from '../../util/errors';
@@ -304,6 +305,7 @@ export class CheckoutPageComponent extends Component {
     );
 
     const isAmountTooLowError = isTransactionInitiateAmountTooLowError(initiateOrderError);
+    const isChargeDisabledError = isTransactionChargeDisabledError(initiateOrderError);
     const isBookingTimeNotAvailableError = isTransactionInitiateBookingTimeNotAvailableError(
       initiateOrderError
     );
@@ -321,6 +323,12 @@ export class CheckoutPageComponent extends Component {
       initiateOrderErrorMessage = (
         <p className={css.orderError}>
           <FormattedMessage id="CheckoutPage.bookingTimeNotAvailableMessage" />
+        </p>
+      );
+    } else if (!listingNotFound && isChargeDisabledError) {
+      initiateOrderErrorMessage = (
+        <p className={css.orderError}>
+          <FormattedMessage id="CheckoutPage.chargeDisabledMessage" />
         </p>
       );
     } else if (!listingNotFound && stripeErrors && stripeErrors.length > 0) {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -79,6 +79,7 @@
   "BookingPanel.perUnit": "per unit",
   "BookingPanel.subTitleClosedListing": "Sorry, this listing has been closed.",
   "CheckoutPage.bookingTimeNotAvailableMessage": "Unfortunately, the requested time is already booked.",
+  "CheckoutPage.chargeDisabledMessage": "This provider's payout information is incomplete so this listing cannot be booked. Please contact the administrator.",
   "CheckoutPage.errorlistingLinkText": "the sauna page",
   "CheckoutPage.goToLandingPage": "Go to homepage",
   "CheckoutPage.hostedBy": "Hosted by {name}",


### PR DESCRIPTION
If provider's Stripe account is missing information, customer might face strange error message from Stripe. This changes it to more understandable:

![Screenshot 2019-05-23 at 15 08 03](https://user-images.githubusercontent.com/717315/58251590-a6ce7900-7d6c-11e9-94f6-8cbe9948368b.png)
