### PR TITLE
Release v2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+## [v2.17.0] 2019-05-23
+
 - [change] Mapbox library dependencies updated to v1.0.0.
   [#1099](https://github.com/sharetribe/flex-template-web/pull/1099)
   - Note: Mapbox changed their pricing scheme!
@@ -33,6 +35,8 @@ way to update this template, but currently, we follow a pattern:
   but handled separately. [#1088](https://github.com/sharetribe/flex-template-web/pull/1088)
 - [change] Move Stripe SDK call from `StripePaymentForm` to `stripe.duck.js` for consistency.
   [#1086](https://github.com/sharetribe/flex-template-web/pull/1086)
+
+  [v2.17.0]: https://github.com/sharetribe/flex-template-web/compare/v2.16.0...v2.17.0
 
 ## [v2.16.0] 2019-05-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Note: **Mapbox pricing has changed!**

Changes:
- [change] Mapbox library dependencies updated to v1.0.0. [#1099](https://github.com/sharetribe/flex-template-web/pull/1099)
  - **Note: Mapbox changed their pricing scheme!**
  - Read more from [the pull request](https://github.com/sharetribe/flex-template-web/pull/1099)
- [fix] missing provider information (like SSN in the US), might cause a payment to fail on
  `CheckoutPage`. This improves the related error message. [#1098](https://github.com/sharetribe/flex-template-web/pull/1098)
- [fix] Menu needs to wait for mounting to calculate dimensions properly. [#1096](https://github.com/sharetribe/flex-template-web/pull/1096)
- [fix] Renamed Component.example.css files to ComponentExample.css to fix a bug introduced in one of the library updates. [#1095](https://github.com/sharetribe/flex-template-web/pull/1095)
- [add] `rawOnly` flag for Styleguide examples using fixed positioning or full-page dimensions [#1094](https://github.com/sharetribe/flex-template-web/pull/1094)
- [fix] Show error when typing credit card number if e.g. the number is invalid. Fixes bug that was
  introduced in PR #1088. [#1092](https://github.com/sharetribe/flex-template-web/pull/1092)
- [change] **Use Final Form on `StripePaymentForm`** for consistency. Note that card form Stripe
  Elements in `StripePaymentForm` is not a Final Form field so it's not available trough Final Form
 but handled separately. [#1088](https://github.com/sharetribe/flex-template-web/pull/1088)
- [change] Move **Stripe SDK call from `StripePaymentForm` to `stripe.duck.js`** for consistency. [#1086](https://github.com/sharetribe/flex-template-web/pull/1086)
