### PR TITLE
Fix bug in showing the review link after other party has already reviewed it

### DIFF
--- a/.auditrc
+++ b/.auditrc
@@ -2,4 +2,6 @@ exports.exceptions = [
   // Add exceptions to audit script:
   // // Severity: low, lodash (< 4.17.5), used heavily in our CRA fork
   // "https://npmjs.com/advisories/577",
+  // Temporarily skip warning about axios until SDK is updated
+  "https://npmjs.com/advisories/880", 
 ];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] Fix a bug in showing review links. Because of the bug the second review link was not visible
+  in `ActivityFeed`. [#1106](https://github.com/sharetribe/flex-template-web/pull/1106)
 - [fix] Emptying the priceFilter component in the searchPage caused a page breaking error.
   [#1101](https://github.com/sharetribe/flex-template-web/pull/1101)
 


### PR DESCRIPTION
Because of the bug, the second review link was not visible
  in `ActivityFeed`. Instead, the link to the first review was shown even if the user had already sent the review. 

This bug was introduced most likely in FTW v2.10.0 when the `ActivityFeed` was refactored. 