### PR TITLE
Clear cardtoken before redirecting

### DIFF
--- a/.auditrc
+++ b/.auditrc
@@ -2,6 +2,4 @@ exports.exceptions = [
   // Add exceptions to audit script:
   // // Severity: low, lodash (< 4.17.5), used heavily in our CRA fork
   // "https://npmjs.com/advisories/577",
-  // Temporarily skip warning about axios until SDK is updated
-  "https://npmjs.com/advisories/880", 
 ];

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,15 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] `stripeCardToken` didn't update when the user tried to book the same listing for a second
+  time. This update will clear the old cardtoken from Redux store when redirecting to
+  `TransactionPage`. [#1114](https://github.com/sharetribe/flex-template-web/pull/1114)
 - [fix] In `LineItemProviderCommissionMaybe.js` file check that `providerCommissionLineItem` exists.
   In default transaction process the `providerCommissionLineItem` can be expected to be there but if
   the process is using only customer commission there will be error.
   [#1112](https://github.com/sharetribe/flex-template-web/pull/1112)
-- [security] Update Flex SDK version to v1.4.1. The new version updates depencencies with security issues
-  [#1111](https://github.com/sharetribe/flex-template-web/pull/1111)
+- [security] Update Flex SDK version to v1.4.1. The new version updates depencencies with security
+  issues [#1111](https://github.com/sharetribe/flex-template-web/pull/1111)
 - [fix] Fix a bug in showing review links. Because of the bug the second review link was not visible
   in `ActivityFeed`. [#1106](https://github.com/sharetribe/flex-template-web/pull/1106)
 - [fix] Emptying the priceFilter component in the searchPage caused a page breaking error.

--- a/src/containers/CheckoutPage/CheckoutPage.js
+++ b/src/containers/CheckoutPage/CheckoutPage.js
@@ -38,7 +38,7 @@ import {
   setInitialValues,
   speculateTransaction,
 } from './CheckoutPage.duck';
-import { createStripePaymentToken } from '../../ducks/stripe.duck.js';
+import { createStripePaymentToken, clearStripePaymentToken } from '../../ducks/stripe.duck.js';
 import config from '../../config';
 
 import { storeData, storedData, clearData } from './CheckoutPageSessionHelpers';
@@ -152,6 +152,7 @@ export class CheckoutPageComponent extends Component {
       sendOrderRequest,
       sendOrderRequestAfterEnquiry,
       speculatedTransaction,
+      onClearStripePaymentToken,
       dispatch,
     } = this.props;
 
@@ -190,6 +191,7 @@ export class CheckoutPageComponent extends Component {
         const orderDetailsPath = pathByRouteName('OrderDetailsPage', routes, {
           id: orderId.uuid,
         });
+        onClearStripePaymentToken();
         clearData(STORAGE_KEY);
         history.push(orderDetailsPath);
       })
@@ -606,6 +608,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(initiateOrderAfterEnquiry(transactionId, params)),
   fetchSpeculatedTransaction: params => dispatch(speculateTransaction(params)),
   onCreateStripePaymentToken: params => dispatch(createStripePaymentToken(params)),
+  onClearStripePaymentToken: () => dispatch(clearStripePaymentToken()),
 });
 
 const CheckoutPage = compose(

--- a/src/ducks/stripe.duck.js
+++ b/src/ducks/stripe.duck.js
@@ -22,6 +22,8 @@ export const CREATE_PAYMENT_TOKEN_REQUEST = 'app/stripe/CREATE_PAYMENT_TOKEN_REQ
 export const CREATE_PAYMENT_TOKEN_SUCCESS = 'app/stripe/CREATE_PAYMENT_TOKEN_SUCCESS';
 export const CREATE_PAYMENT_TOKEN_ERROR = 'app/stripe/CREATE_PAYMENT_TOKEN_ERROR';
 
+export const CLEAR_PAYMENT_TOKEN = 'app/stripe/CLEAR_PAYMENT_TOKEN';
+
 // ================ Reducer ================ //
 
 const initialState = {
@@ -112,6 +114,8 @@ export default function reducer(state = initialState, action = {}) {
     case CREATE_PAYMENT_TOKEN_ERROR:
       console.error(payload);
       return { ...state, stripePaymentTokenError: payload, stripePaymentTokenInProgress: false };
+    case CLEAR_PAYMENT_TOKEN:
+      return { ...state, stripePaymentToken: null };
 
     default:
       return state;
@@ -182,6 +186,10 @@ export const createPaymentTokenError = payload => ({
   type: CREATE_PAYMENT_TOKEN_ERROR,
   payload,
   error: true,
+});
+
+export const clearPaymentToken = () => ({
+  type: CLEAR_PAYMENT_TOKEN,
 });
 
 // ================ Thunks ================ //
@@ -514,4 +522,8 @@ export const createStripePaymentToken = params => dispatch => {
       log.error(err, 'create-stripe-payment-token-failed', { stripeMessage });
       throw e;
     });
+};
+
+export const clearStripePaymentToken = () => dispatch => {
+  dispatch(clearPaymentToken());
 };


### PR DESCRIPTION
`stripeCardToken` didn't update when the user tried to book the same listing for a second
  time. This update will clear the old card token from Redux store when redirecting to
  `TransactionPage`.