### PR TITLE
Temporarily remove audit CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,4 +99,3 @@ workflows:
       - format
       - test
       - build
-      - audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] temporarily remove audit CI job.
+  [#1136](https://github.com/sharetribe/flex-template-web/pull/1136)
 - [change] Update outdated dependencies. This includes updating lodash to fix the security issue.
   [#1135](https://github.com/sharetribe/flex-template-web/pull/1135)
 


### PR DESCRIPTION
Audit creates so big json file that js runs out of memory.