### PR TITLE
user.duck.js can fetch currentUser with different relationships.

### DIFF
--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -40,6 +40,20 @@ export const SEND_VERIFICATION_EMAIL_ERROR = 'app/user/SEND_VERIFICATION_EMAIL_E
 
 // ================ Reducer ================ //
 
+const mergeCurrentUser = (oldCurrentUser, newCurrentUser) => {
+  const { id: oId, type: oType, attributes: oAttr, ...oldRelationships } = oldCurrentUser || {};
+  const { id, type, attributes, ...relationships } = newCurrentUser || {};
+
+  // Passing null will remove currentUser entity.
+  // Only relationships are merged.
+  // TODO figure out if sparse fields handling needs a better handling.
+  return newCurrentUser === null
+    ? null
+    : oldCurrentUser === null
+    ? newCurrentUser
+    : { id, type, attributes, ...oldRelationships, ...relationships };
+};
+
 const initialState = {
   currentUser: null,
   currentUserShowError: null,
@@ -59,7 +73,7 @@ export default function reducer(state = initialState, action = {}) {
     case CURRENT_USER_SHOW_REQUEST:
       return { ...state, currentUserShowError: null };
     case CURRENT_USER_SHOW_SUCCESS:
-      return { ...state, currentUser: payload };
+      return { ...state, currentUser: mergeCurrentUser(state.currentUser, payload) };
     case CURRENT_USER_SHOW_ERROR:
       // eslint-disable-next-line no-console
       console.error(payload);
@@ -291,7 +305,7 @@ export const fetchCurrentUserNotifications = () => (dispatch, getState, sdk) => 
     .catch(e => dispatch(fetchCurrentUserNotificationsError(storableError(e))));
 };
 
-export const fetchCurrentUser = () => (dispatch, getState, sdk) => {
+export const fetchCurrentUser = (params = null) => (dispatch, getState, sdk) => {
   dispatch(currentUserShowRequest());
   const { isAuthenticated } = getState().Auth;
 
@@ -301,13 +315,13 @@ export const fetchCurrentUser = () => (dispatch, getState, sdk) => {
     return Promise.resolve({});
   }
 
-  const params = {
+  const parameters = params || {
     include: ['profileImage', 'stripeAccount'],
     'fields.image': ['variants.square-small', 'variants.square-small2x'],
   };
 
   return sdk.currentUser
-    .show(params)
+    .show(parameters)
     .then(response => {
       const entities = denormalisedResponseEntities(response);
       if (entities.length !== 1) {


### PR DESCRIPTION
`user.duck.js` can fetch currentUser with different relationships.
It merges old and new relationships.

After this change, we could call `fetchCurrentUser` function as:
```js
fetchCurrentUser({ include: ['stripeCustomer.defaultPaymentMethod'] });
```
