### PR TITLE
Fix FieldBirthdayInput: valueFromForm prop didn't work anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] Bug fix: valueFromForm prop wasn't passed through different subcomponents.
+  [#1182](https://github.com/sharetribe/flex-template-web/pull/1182)
 - [add] Update German and French translations.
   [#1184](https://github.com/sharetribe/flex-template-web/pull/1184)
 - [change] Migrate from `react-helmet` to `react-helmet-async`

--- a/src/components/FieldBirthdayInput/FieldBirthdayInput.example.js
+++ b/src/components/FieldBirthdayInput/FieldBirthdayInput.example.js
@@ -28,7 +28,7 @@ const FormComponent = props => (
             name="birthday"
             label="Date of birth"
             format={identity}
-            valueFromForm={values.birthDate}
+            valueFromForm={values.birthday}
             validate={validators.composeValidators(required, minAgeRequired)}
           />
         </form>
@@ -43,6 +43,23 @@ export const Empty = {
     onChange: formState => {
       const birthday = formState.values.birthday;
       if (birthday) {
+        console.log('birthday changed to:', birthday);
+      }
+    },
+    onSubmit: values => {
+      console.log('BirthdayInput.Form submitted values:', values);
+    },
+  },
+  group: 'custom inputs',
+};
+
+export const WithInitialValue = {
+  component: FormComponent,
+  props: {
+    initialValues: { birthday: new Date('1982-03-01') },
+    onChange: formState => {
+      const birthday = formState.values.birthday;
+      if (birthday && formState.dirty) {
         console.log('birthday changed to:', birthday);
       }
     },

--- a/src/components/FieldBirthdayInput/FieldBirthdayInput.js
+++ b/src/components/FieldBirthdayInput/FieldBirthdayInput.js
@@ -259,6 +259,7 @@ const FieldBirthdayInputComponent = props => {
     disabled,
     input,
     meta,
+    valueFromForm,
   } = props;
   const { valid, invalid, touched, error } = meta;
 
@@ -287,6 +288,7 @@ const FieldBirthdayInputComponent = props => {
     monthLabel,
     yearLabel,
     disabled,
+    valueFromForm,
     ...input,
   };
   const classes = classNames(rootClassName || css.fieldRoot, className);


### PR DESCRIPTION
Bug fix: `valueFromForm` prop wasn't passed through different subcomponents.
(There's probably lots of room to rewrite this component, but that's now postponed)