### PR TITLE
Fix componentWillUnmount on ProfileSettingsForm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] ProfileSettingsForm: clear correct timeout.
+  [#1185](https://github.com/sharetribe/flex-template-web/pull/1185)
 - [fix] `availabilityPlan` prop in `EditListingAvailabilityForm` was missing.
   [#1183](https://github.com/sharetribe/flex-template-web/pull/1183)
 - [fix] Bug fix: valueFromForm prop wasn't passed through different subcomponents.

--- a/src/forms/ProfileSettingsForm/ProfileSettingsForm.js
+++ b/src/forms/ProfileSettingsForm/ProfileSettingsForm.js
@@ -37,7 +37,7 @@ class ProfileSettingsFormComponent extends Component {
   }
 
   componentWillUnmount() {
-    window.clearTimeout(this.blurTimeoutId);
+    window.clearTimeout(this.uploadDelayTimeoutId);
   }
 
   render() {


### PR DESCRIPTION
Old copy-paste bug: clearing nonexistent timeout instead of the correct one.