### PR TITLE
Circumvent lodash vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [fix] Lodash vulnerability: enforce newer version for react-google-maps and react-dates
+  [#1188](https://github.com/sharetribe/flex-template-web/pull/1188)
 - [change] Update `React`, `react-test-renderer` and `react-dom` to 16.9.0. After these updates old
   lifecycle methods `componentWillMount`, `componentWillUpdate` and `componentWillUpdate` will cause
   deprecation warnings. Check the updated components from the PR

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "prettier": "^1.18.2"
   },
   "resolutions": {
+    "react-dates/lodash": "^4.17.14",
+    "react-google-maps/lodash": "^4.17.14",
     "react-test-renderer": "^16.9.0"
   },
   "scripts": {


### PR DESCRIPTION
Lodash vulnerability: enforce newer version for `react-google-maps` and `react-dates`
We need to remove these resolutions when those dependencies update themselves.