### PR TITLE
New release: v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+## [v3.4.0] 2019-08-29
+
 - [change] Update `react-intl` to 3.1.13. More information about the changes can be found from
   [Upgrade guide for react-intl@3.x](https://github.com/formatjs/react-intl/blob/master/docs/Upgrade-Guide.md)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
### Dependency updates

- `react-intl`: React Intl was the most problematic to upgrade.

  - Proptype `intlShape` was removed so we needed to create it again. Because of this we added a new `util/reactIntl.js` file. This file is now used to wrap all the react-intl related imports.
  - `addLocaleDate` function was removed and react-intl library is now relying on native Intl APIs: [Intl.PluralRules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/PluralRules) and [Intl.RelativeTimeFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RelativeTimeFormat). In order to support older browsers we needed to add `intl-pluralrules` and `intl-relativetimeformat` to `util/polyfills.js`
  - Also, Node must be now compiled with `full-icu` which caused changes to `start` and `test`
    scripts in `package.json`. We also needed to add a specific config for `nodemon`
  - Default `textComponent`in `IntlProvider` changed to `React.Fragment` so we need to explicitly
    set `textComponent` to `span`. Otherwise, all the snapshots would have changed and it might
    affect to UI if there are styles added to these spans generally in customization projects.

  **Note**: `FormattedMessage` component now supports
  [`tagName` prop](https://github.com/formatjs/react-intl/blob/master/docs/Components.md#formattedmessage) and [improved rich-text formatting](https://github.com/formatjs/react-intl/blob/master/docs/Components.md#rich-text-formatting).

  **Read more from [Upgrade guide for react-intl@3.x](https://github.com/formatjs/react-intl/blob/master/docs/Upgrade-Guide.md)**

- Updated `react`, `react-test-renderer` and `react-dom` to 16.9.0. After these updates old
  lifecycle methods `componentWillMount`, `componentWillUpdate` and `componentWillUpdate` will cause deprecation warnings. Check the updated components from the PR [#1172](https://github.com/sharetribe/flex-template-web/pull/1172)

- Migrate from `react-helmet` to `react-helmet-async`, since react-helmet wasn't updated often
  enough and `react-helmet-async` was supporting React 16+ better. This caused changes to app.js (`<HelmetProvider>` added) and it changes the way how Helmet needs to be imported. [#1179](https://github.com/sharetribe/flex-template-web/pull/1179)

  - `import Helmet from 'react-helmet';` vs `import { Helmet } from 'react-helmet-async';`

- `sanitize.css` was moved to own file instead of importing it from _npm_ package because updating it accidentally might break the UI.
- `react-redux`: [v5.1.1 -> v7.1.1](https://github.com/reduxjs/react-redux/releases) Note: `connect` is now using Hooks.

  - [In FTW](https://github.com/sharetribe/flex-template-web/pull/1178), app.test.js had to be split to SSR aka node environment tests and client tests since JSDOM environment in Jest doesn't work well with [the environment detection hack](https://github.com/reduxjs/react-redux/issues/1373) that `react-redux` uses internally.

- `seedrandom`: [v2.4.4 -> v3.0.3](https://github.com/davidbau/seedrandom#version-notes). (FTW wasn't affected.)
- `inquirer`: [v6.5.0 -> v7.0.0](https://github.com/SBoudrias/Inquirer.js/releases). (They dropped support for Node 6)

- `final-form`, `final-form-arrays`, `react-final-form` and `react-final-form-arrays`. This forced us to make some code changes:

  - Old recommendation of by-passing default field formatting or parsing isn't accepted anymore
    - `format={null}` => use identity function instead: `format={v => v}`
    - `parse={null}` => use identity function instead: `parse={v => v}`
  - Final Form passes input props (name, value, onChange, onBlur, etc. ) grouped inside `input` key
    - those props now include `type` attribute too.
  - We had old form naming pattern with prop 'form', which now conflicted with updated Final Form (The 'form' prop was used when Redux-Form was the form library)
  - **Note**: most of the changes came from **`react-final-form`**: 4.0.2 > [v5.0.0](https://github.com/final-form/react-final-form/releases/tag/v5.0.0) -> [v6.0.0](https://github.com/final-form/react-final-form/releases/tag/v6.0.0) -> v6.3.1

- `react-dates`: [v18.5.0 -> v20.3.0](https://github.com/airbnb/react-dates/blob/master/CHANGELOG.md)
- `prettier`: [v1.17.0 -> v1.18.2](https://github.com/prettier/prettier/blob/master/CHANGELOG.md#1182)  
  - Check if you need to format your code: `yarn run format`

- `path-to-regexp`: [v2.4.0 -> v3.0.0](https://github.com/pillarjs/path-to-regexp/blob/master/History.md#300--2019-01-13). It is used in create populated paths in our route generation.

- `sharetribe-scripts`: [v3.0.0 -> v3.1.1](https://github.com/sharetribe/create-react-app/blob/master/CHANGELOG.md)

  - Remove `jsx-a11y/href-no-hash` for eslint reference since it didn't exist anymore: `/* eslint-disable jsx-a11y/href-no-hash */`

- Sentry: [v4.5.1 -> v5.6.2](https://github.com/getsentry/sentry-javascript/blob/master/CHANGELOG.md)

### Other changes

- Update to German and French translations. [#1184](https://github.com/sharetribe/flex-template-web/pull/1184)

- Bug fixes to [ProfileSettingsForm](https://github.com/sharetribe/flex-template-web/pull/1185), [EditListingAvailabilityForm](https://github.com/sharetribe/flex-template-web/pull/1183), and [FieldBirthdayInput](https://github.com/sharetribe/flex-template-web/pull/1182)

- Lodash vulnerability: we enforced a newer version for `react-google-maps` and `react-dates` through [package.json resolutions](https://github.com/sharetribe/flex-template-web/pull/1188)
