### PR TITLE
New release: v3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ way to update this template, but currently, we follow a pattern:
   `SearchMapWithGoogleMap` to abide to React rules and do not `unmountComponentAtNode` when a
   component is rendered by React and use `appendChild` on `onAdd` instead of `draw` to
   [improve performance](https://github.com/tomchentw/react-google-maps/issues/817).
+  [#1200](https://github.com/sharetribe/flex-template-web/pull/1200)
 - [fix] fix `CustomOverlayView` in `SearchMapWithGoogleMap` to work with new `react-intl` version,
   overriding `render` method to render child object by using `createPortal` instead of
   `unstable_renderSubtreeIntoContainer`.
+  [#1200](https://github.com/sharetribe/flex-template-web/pull/1200)
 
 ## [v3.5.0] 2019-08-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## [v3.5.1] 2019-09-16

- [add] add orverriding function `onAdd` and `onRemove` for `CustomOverlayView` in
 `SearchMapWithGoogleMap` to abide to React rules and do not `unmountComponentAtNode` when a component is rendered by React and use `appendChild` on `onAdd` instead of `draw` to
  [improve performance](https://github.com/tomchentw/react-google-maps/issues/817).
  [#1200](https://github.com/sharetribe/flex-template-web/pull/1200)

- [fix] fix `CustomOverlayView` in `SearchMapWithGoogleMap` to work with new `react-intl` version, overriding `render` method to render child object by using `createPortal` instead of
  `unstable_renderSubtreeIntoContainer`.
  [#1200](https://github.com/sharetribe/flex-template-web/pull/1200)
