### PR TITLE
Update default process alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ way to update this template, but currently, we follow a pattern:
 
 - [fix] AvailabilityPlan doesn't need to have entries for every day.
   [#1214](https://github.com/sharetribe/flex-template-web/pull/1214)
+- [change] Default transaction process alias changed
+  [#1219](https://github.com/sharetribe/flex-template-web/pull/1219)
 
 ## [v3.5.1] 2019-09-16
 

--- a/src/config.js
+++ b/src/config.js
@@ -32,7 +32,7 @@ const sortSearchByDistance = false;
 //
 // In a way, 'processAlias' defines which transaction process (or processes)
 // this particular web application is able to handle.
-const bookingProcessAlias = 'sca-preauth-nightly-booking/release-1';
+const bookingProcessAlias = 'preauth-nightly-booking/release-1';
 
 // The transaction line item code for the main unit type in bookings.
 //


### PR DESCRIPTION
Update default alias to match the one that is used by default for new marketplaces.