### PR TITLE
Update  @formatjs/intl-relativetimeformat to v4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2019-XX-XX
 
+- [change] Update @formatjs/intl-relativetimeformat from 2.8.3 to 4.2.1
+  [#1222](https://github.com/sharetribe/flex-template-web/pull/1222)
 - [fix] Use currency of the `lineItem` on every line of the `BookingBreakdown` if possible.
   [#1221](https://github.com/sharetribe/flex-template-web/pull/1221)
 - [fix] AvailabilityPlan doesn't need to have entries for every day.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {
-    "@formatjs/intl-relativetimeformat": "^2.8.2",
+    "@formatjs/intl-relativetimeformat": "^4.2.1",
     "@mapbox/polyline": "^1.0.0",
     "@sentry/browser": "5.6.2",
     "@sentry/node": "5.6.2",

--- a/src/util/polyfills.js
+++ b/src/util/polyfills.js
@@ -43,10 +43,9 @@ if (!Intl.PluralRules) {
 // To support  browsers that do not have Intl.RelativeTimeFormat (e.g IE11, Edge, Safari 12-), include this polyfill in your build along with individual CLDR data for each locale you support.
 if (!Intl.RelativeTimeFormat) {
   require('@formatjs/intl-relativetimeformat/polyfill');
-  require('@formatjs/intl-relativetimeformat/dist/include-aliases'); // Optional, if you care about edge cases in locale resolution, e.g zh-CN -> zh-Hans-CN
   require('@formatjs/intl-relativetimeformat/dist/locale-data/en');
 
   // By default, this library comes with en data. To load additional locale, you need include them on demand.
   // e.g.
-  require('@formatjs/intl-relativetimeformat/dist/locale-data/fr');
+  // require('@formatjs/intl-relativetimeformat/dist/locale-data/fr');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -842,12 +842,24 @@
   dependencies:
     "@formatjs/intl-utils" "^0.6.1"
 
+"@formatjs/intl-relativetimeformat@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-relativetimeformat/-/intl-relativetimeformat-4.2.1.tgz#bee6ffb2227dfde001d7214deb8ab6c2bde4077b"
+  integrity sha512-NIrK1jgDStuR9DEoJV8Iju6cj1Ffa7qr8qJ46nQGGH6c/222rZSdlEqd0qoX7AFMRpu2Br8OrSwNLX4IUo0nuw==
+  dependencies:
+    "@formatjs/intl-utils" "^1.4.0"
+
 "@formatjs/intl-utils@^0.6.1":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-0.6.1.tgz#7661afd5abb2161dc8ac92238be9432aee28ad38"
   integrity sha512-CthSQc/GV94y0cdMpTM69cwH98T/qx9twaZZXh9VZ6B0nL+2KptE5fXqcde4ffrHMZx1bPZJTIpwky4X1Is00A==
   dependencies:
     date-fns "^2.0.0"
+
+"@formatjs/intl-utils@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-1.4.0.tgz#b59fdf78bbae9f99c500a298bf73b1945f5991f1"
+  integrity sha512-z5HyJumGzORM+5SpvkAlp/hu0AHDeZcUNKSmj9NjS7kWxOGZMuAdS3X1K5XiE0j5I8r8s8SIaz0IQOdMA1WFeA==
 
 "@hapi/address@2.x.x":
   version "2.0.0"


### PR DESCRIPTION
Biggest changes related to the update are:
- Language aliases are now built-in so there is no need to explicitly include it. This provides correctness across our polyfills
- en locale data is no longer bundled by default with the polyfill 